### PR TITLE
ci: pass --project-name to wrangler pages deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,7 +30,7 @@ jobs:
           NODE_ENV: preview
 
       - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy .svelte-kit/cloudflare --branch preview
+        run: npx wrangler pages deploy .svelte-kit/cloudflare --project-name adventure-spark --branch preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -54,7 +54,7 @@ jobs:
           NODE_ENV: production
 
       - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy .svelte-kit/cloudflare
+        run: npx wrangler pages deploy .svelte-kit/cloudflare --project-name adventure-spark
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
This pull request updates the Cloudflare Pages deployment steps in both the preview and production GitHub Actions workflows to explicitly specify the project name during deployment. This helps ensure deployments are correctly associated with the intended Cloudflare Pages project.

**Deployment workflow improvements:**

* [`.github/workflows/deploy-preview.yml`](diffhunk://#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0L33-R33): Added the `--project-name adventure-spark` flag to the Cloudflare Pages deploy command to explicitly set the project for preview deployments.
* [`.github/workflows/deploy-prod.yml`](diffhunk://#diff-4ce342fb97e7d7feb8a578c91ba89fe4c27ddf16b4306909fe6d90220141913dL57-R57): Added the `--project-name adventure-spark` flag to the Cloudflare Pages deploy command to explicitly set the project for production deployments.