### PR TITLE
Add tile layer switching and SVG markers

### DIFF
--- a/src/lib/components/ListingMap.svelte
+++ b/src/lib/components/ListingMap.svelte
@@ -117,19 +117,21 @@
   />
 </svelte:head>
 
-<div class="relative isolate w-full rounded-xl overflow-hidden" style="height: {height};">
+<div class="isolate w-full rounded-xl overflow-hidden" style="height: {height};">
   <div bind:this={mapContainer} class="w-full h-full"></div>
+</div>
 
-  <!-- Tile layer toggle -->
-  <div class="absolute bottom-2 right-2 z-[1000] flex rounded-md overflow-hidden shadow-md">
+<!-- Tile layer toggle -->
+<div class="mt-1.5 flex justify-end">
+  <div class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
     {#each TILE_LAYERS as layer}
       <button
         type="button"
         on:click={() => switchLayer(layer.id)}
-        class="px-2 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
+        class="px-2.5 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
           {activeLayerId === layer.id
             ? 'bg-indigo-600 text-white'
-            : 'bg-white text-gray-700 hover:bg-gray-50'}"
+            : 'bg-white text-gray-600 hover:bg-gray-50'}"
       >
         {layer.label}
       </button>

--- a/src/lib/components/ListingMap.svelte
+++ b/src/lib/components/ListingMap.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import type L from "leaflet";
+  import { TILE_LAYERS, DEFAULT_TILE_LAYER, type TileLayerId } from "$lib/utils/map-tiles";
 
   export let markers: Array<{
     id: string;
@@ -22,15 +23,34 @@
   let map: L.Map | null = null;
   let leaflet: typeof L | null = null;
   let markerLayer: L.LayerGroup | null = null;
+  let activeTileLayer: L.TileLayer | null = null;
+  let activeLayerId: TileLayerId = DEFAULT_TILE_LAYER.id;
 
   function makeIcon(color: string) {
     const hex = colorMap[color] ?? colorMap.emerald;
     return leaflet!.divIcon({
       className: "",
-      html: `<div style="width:14px;height:14px;border-radius:50%;background:${hex};border:2.5px solid white;box-shadow:0 1px 5px rgba(0,0,0,0.45);"></div>`,
-      iconAnchor: [7, 7],
-      popupAnchor: [0, -12],
+      html: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 32" width="24" height="32" style="filter:drop-shadow(0 2px 4px rgba(0,0,0,0.35))">
+        <path d="M12 0C5.4 0 0 5.4 0 12c0 9 12 20 12 20S24 21 24 12C24 5.4 18.6 0 12 0z" fill="${hex}"/>
+        <circle cx="12" cy="11" r="4" fill="white" opacity="0.9"/>
+      </svg>`,
+      iconSize: [24, 32],
+      iconAnchor: [12, 32],
+      popupAnchor: [0, -32],
     });
+  }
+
+  function switchLayer(id: TileLayerId) {
+    if (!map || !leaflet || id === activeLayerId) return;
+    const def = TILE_LAYERS.find((t) => t.id === id)!;
+    if (activeTileLayer) {
+      activeTileLayer.remove();
+    }
+    activeTileLayer = leaflet.tileLayer(def.url, {
+      attribution: def.attribution,
+      maxZoom: def.maxZoom,
+    }).addTo(map);
+    activeLayerId = id;
   }
 
   function renderMarkers() {
@@ -69,12 +89,9 @@
 
     map = leaflet.map(mapContainer).setView([39.5, -98.35], 4);
 
-    leaflet
-      .tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 19,
-      })
+    const def = DEFAULT_TILE_LAYER;
+    activeTileLayer = leaflet
+      .tileLayer(def.url, { attribution: def.attribution, maxZoom: def.maxZoom })
       .addTo(map);
 
     markerLayer = leaflet.layerGroup().addTo(map);
@@ -100,11 +117,25 @@
   />
 </svelte:head>
 
-<div
-  bind:this={mapContainer}
-  style="height: {height};"
-  class="w-full rounded-xl overflow-hidden"
-></div>
+<div class="relative isolate w-full rounded-xl overflow-hidden" style="height: {height};">
+  <div bind:this={mapContainer} class="w-full h-full"></div>
+
+  <!-- Tile layer toggle -->
+  <div class="absolute bottom-2 right-2 z-[1000] flex rounded-md overflow-hidden shadow-md">
+    {#each TILE_LAYERS as layer}
+      <button
+        type="button"
+        on:click={() => switchLayer(layer.id)}
+        class="px-2 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
+          {activeLayerId === layer.id
+            ? 'bg-indigo-600 text-white'
+            : 'bg-white text-gray-700 hover:bg-gray-50'}"
+      >
+        {layer.label}
+      </button>
+    {/each}
+  </div>
+</div>
 
 <style>
   :global(.leaflet-container) {

--- a/src/lib/components/ListingMap.svelte
+++ b/src/lib/components/ListingMap.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import type L from "leaflet";
-  import { TILE_LAYERS, DEFAULT_TILE_LAYER, type TileLayerId } from "$lib/utils/map-tiles";
+  import { TILE_LAYERS, DEFAULT_TILE_LAYER, getTileLayer, type TileLayerId } from "$lib/utils/map-tiles";
 
   export let markers: Array<{
     id: string;
@@ -42,7 +42,7 @@
 
   function switchLayer(id: TileLayerId) {
     if (!map || !leaflet || id === activeLayerId) return;
-    const def = TILE_LAYERS.find((t) => t.id === id)!;
+    const def = getTileLayer(id);
     if (activeTileLayer) {
       activeTileLayer.remove();
     }
@@ -123,10 +123,11 @@
 
 <!-- Tile layer toggle -->
 <div class="mt-1.5 flex justify-end">
-  <div class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
+  <div role="group" aria-label="Map tile layer" class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
     {#each TILE_LAYERS as layer}
       <button
         type="button"
+        aria-pressed={activeLayerId === layer.id}
         on:click={() => switchLayer(layer.id)}
         class="px-2.5 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
           {activeLayerId === layer.id

--- a/src/lib/components/LocationMap.svelte
+++ b/src/lib/components/LocationMap.svelte
@@ -81,19 +81,21 @@
   />
 </svelte:head>
 
-<div class="relative isolate w-full rounded-lg overflow-hidden" style="height: {height};">
+<div class="isolate w-full rounded-lg overflow-hidden" style="height: {height};">
   <div bind:this={mapContainer} class="w-full h-full"></div>
+</div>
 
-  <!-- Tile layer toggle -->
-  <div class="absolute bottom-2 right-2 z-[1000] flex rounded-md overflow-hidden shadow-md">
+<!-- Tile layer toggle -->
+<div class="mt-1.5 flex justify-end">
+  <div class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
     {#each TILE_LAYERS as layer}
       <button
         type="button"
         on:click={() => switchLayer(layer.id)}
-        class="px-2 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
+        class="px-2.5 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
           {activeLayerId === layer.id
             ? 'bg-indigo-600 text-white'
-            : 'bg-white text-gray-700 hover:bg-gray-50'}"
+            : 'bg-white text-gray-600 hover:bg-gray-50'}"
       >
         {layer.label}
       </button>

--- a/src/lib/components/LocationMap.svelte
+++ b/src/lib/components/LocationMap.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import type L from "leaflet";
-  import { TILE_LAYERS, DEFAULT_TILE_LAYER, type TileLayerId } from "$lib/utils/map-tiles";
+  import { TILE_LAYERS, DEFAULT_TILE_LAYER, getTileLayer, type TileLayerId } from "$lib/utils/map-tiles";
 
   export let latitude: number;
   export let longitude: number;
@@ -29,7 +29,7 @@
 
   function switchLayer(id: TileLayerId) {
     if (!map || !leaflet || id === activeLayerId) return;
-    const def = TILE_LAYERS.find((t) => t.id === id)!;
+    const def = getTileLayer(id);
     if (activeTileLayer) {
       activeTileLayer.remove();
     }
@@ -61,7 +61,7 @@
   });
 
   // Update map when coordinates change
-  $: if (map && leaflet && latitude && longitude) {
+  $: if (map && leaflet && latitude != null && longitude != null) {
     map.setView([latitude, longitude], 13);
     if (marker) {
       marker.setLatLng([latitude, longitude]);
@@ -87,10 +87,11 @@
 
 <!-- Tile layer toggle -->
 <div class="mt-1.5 flex justify-end">
-  <div class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
+  <div role="group" aria-label="Map tile layer" class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
     {#each TILE_LAYERS as layer}
       <button
         type="button"
+        aria-pressed={activeLayerId === layer.id}
         on:click={() => switchLayer(layer.id)}
         class="px-2.5 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
           {activeLayerId === layer.id

--- a/src/lib/components/LocationMap.svelte
+++ b/src/lib/components/LocationMap.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
   import type L from "leaflet";
+  import { TILE_LAYERS, DEFAULT_TILE_LAYER, type TileLayerId } from "$lib/utils/map-tiles";
 
   export let latitude: number;
   export let longitude: number;
@@ -10,25 +11,47 @@
   let map: L.Map | null = null;
   let marker: L.Marker | null = null;
   let leaflet: typeof L | null = null;
+  let activeTileLayer: L.TileLayer | null = null;
+  let activeLayerId: TileLayerId = DEFAULT_TILE_LAYER.id;
+
+  function makeMarkerIcon(L: typeof import("leaflet")) {
+    return L.divIcon({
+      className: "",
+      html: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 32" width="24" height="32" style="filter:drop-shadow(0 2px 4px rgba(0,0,0,0.35))">
+        <path d="M12 0C5.4 0 0 5.4 0 12c0 9 12 20 12 20S24 21 24 12C24 5.4 18.6 0 12 0z" fill="#4f46e5"/>
+        <circle cx="12" cy="11" r="4" fill="white" opacity="0.9"/>
+      </svg>`,
+      iconSize: [24, 32],
+      iconAnchor: [12, 32],
+      popupAnchor: [0, -32],
+    });
+  }
+
+  function switchLayer(id: TileLayerId) {
+    if (!map || !leaflet || id === activeLayerId) return;
+    const def = TILE_LAYERS.find((t) => t.id === id)!;
+    if (activeTileLayer) {
+      activeTileLayer.remove();
+    }
+    activeTileLayer = leaflet.tileLayer(def.url, {
+      attribution: def.attribution,
+      maxZoom: def.maxZoom,
+    }).addTo(map);
+    activeLayerId = id;
+  }
 
   onMount(async () => {
-    // Dynamically import Leaflet to avoid SSR issues
     leaflet = (await import("leaflet")).default;
 
-    // Initialize map
     map = leaflet.map(mapContainer).setView([latitude, longitude], 13);
 
-    // Add OpenStreetMap tiles
-    leaflet
-      .tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 19,
-      })
+    const def = DEFAULT_TILE_LAYER;
+    activeTileLayer = leaflet
+      .tileLayer(def.url, { attribution: def.attribution, maxZoom: def.maxZoom })
       .addTo(map);
 
-    // Add marker
-    marker = leaflet.marker([latitude, longitude]).addTo(map);
+    const icon = makeMarkerIcon(leaflet);
+    marker = leaflet.marker([latitude, longitude], { icon }).addTo(map);
   });
 
   onDestroy(() => {
@@ -43,7 +66,8 @@
     if (marker) {
       marker.setLatLng([latitude, longitude]);
     } else {
-      marker = leaflet.marker([latitude, longitude]).addTo(map);
+      const icon = makeMarkerIcon(leaflet);
+      marker = leaflet.marker([latitude, longitude], { icon }).addTo(map);
     }
   }
 </script>
@@ -57,7 +81,25 @@
   />
 </svelte:head>
 
-<div bind:this={mapContainer} style="height: {height};" class="w-full rounded-lg"></div>
+<div class="relative isolate w-full rounded-lg overflow-hidden" style="height: {height};">
+  <div bind:this={mapContainer} class="w-full h-full"></div>
+
+  <!-- Tile layer toggle -->
+  <div class="absolute bottom-2 right-2 z-[1000] flex rounded-md overflow-hidden shadow-md">
+    {#each TILE_LAYERS as layer}
+      <button
+        type="button"
+        on:click={() => switchLayer(layer.id)}
+        class="px-2 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
+          {activeLayerId === layer.id
+            ? 'bg-indigo-600 text-white'
+            : 'bg-white text-gray-700 hover:bg-gray-50'}"
+      >
+        {layer.label}
+      </button>
+    {/each}
+  </div>
+</div>
 
 <style>
   :global(.leaflet-container) {

--- a/src/lib/components/LocationPicker.svelte
+++ b/src/lib/components/LocationPicker.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from "svelte";
   import { MapPin } from "lucide-svelte";
   import type L from "leaflet";
+  import { TILE_LAYERS, DEFAULT_TILE_LAYER, getTileLayer, type TileLayerId } from "$lib/utils/map-tiles";
 
   export let address = "";
   export let city = "";
@@ -15,6 +16,21 @@
   let map: L.Map | null = null;
   let marker: L.Marker | null = null;
   let leaflet: typeof L | null = null;
+  let activeTileLayer: L.TileLayer | null = null;
+  let activeLayerId: TileLayerId = DEFAULT_TILE_LAYER.id;
+
+  function switchLayer(id: TileLayerId) {
+    if (!map || !leaflet || id === activeLayerId) return;
+    const def = getTileLayer(id);
+    if (activeTileLayer) {
+      activeTileLayer.remove();
+    }
+    activeTileLayer = leaflet.tileLayer(def.url, {
+      attribution: def.attribution,
+      maxZoom: def.maxZoom,
+    }).addTo(map);
+    activeLayerId = id;
+  }
 
   onMount(async () => {
     // Dynamically import Leaflet to avoid SSR issues
@@ -26,13 +42,10 @@
 
     map = leaflet.map(mapContainer).setView([defaultLat, defaultLng], latitude ? 13 : 4);
 
-    // Add OpenStreetMap tiles
-    leaflet
-      .tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 19,
-      })
+    // Add default tile layer
+    const def = DEFAULT_TILE_LAYER;
+    activeTileLayer = leaflet
+      .tileLayer(def.url, { attribution: def.attribution, maxZoom: def.maxZoom })
       .addTo(map);
 
     // Add marker if coordinates exist
@@ -125,7 +138,7 @@
     }
   }
 
-  $: if (map && latitude && longitude && leaflet) {
+  $: if (map && latitude != null && longitude != null && leaflet) {
     map.setView([latitude, longitude], 13);
     if (marker) {
       marker.setLatLng([latitude, longitude]);
@@ -174,10 +187,29 @@
   </div>
 
   <!-- Interactive Map -->
-  <div class="border rounded-lg overflow-hidden bg-gray-100 mb-4" style="isolation: isolate;">
+  <div class="border rounded-lg overflow-hidden bg-gray-100" style="isolation: isolate;">
     <div bind:this={mapContainer} class="h-64 w-full"></div>
     <div class="bg-gray-50 px-3 py-2 text-xs text-gray-600 border-t">
       💡 Click on the map to set location, or drag the marker to adjust
+    </div>
+  </div>
+
+  <!-- Tile layer toggle -->
+  <div class="mb-4 flex justify-end">
+    <div role="group" aria-label="Map tile layer" class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
+      {#each TILE_LAYERS as layer}
+        <button
+          type="button"
+          aria-pressed={activeLayerId === layer.id}
+          on:click={() => switchLayer(layer.id)}
+          class="px-2.5 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
+            {activeLayerId === layer.id
+              ? 'bg-indigo-600 text-white'
+              : 'bg-white text-gray-600 hover:bg-gray-50'}"
+        >
+          {layer.label}
+        </button>
+      {/each}
     </div>
   </div>
 

--- a/src/lib/components/WaypointMap.svelte
+++ b/src/lib/components/WaypointMap.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
+  import { TILE_LAYERS, DEFAULT_TILE_LAYER, type TileLayerId } from "$lib/utils/map-tiles";
 
   type Waypoint = {
     lat: number;
@@ -31,6 +32,21 @@
   let drawnMarkers: any[] = [];
   let polyline: any = null;
   let referenceMarker: any = null;
+  let activeTileLayer: any = null;
+  let activeLayerId: TileLayerId = DEFAULT_TILE_LAYER.id;
+
+  function switchLayer(id: TileLayerId) {
+    if (!map || !leaflet || id === activeLayerId) return;
+    const def = TILE_LAYERS.find((t) => t.id === id)!;
+    if (activeTileLayer) {
+      activeTileLayer.remove();
+    }
+    activeTileLayer = leaflet.tileLayer(def.url, {
+      attribution: def.attribution,
+      maxZoom: def.maxZoom,
+    }).addTo(map);
+    activeLayerId = id;
+  }
 
   function emitChange() {
     waypoints = [...waypoints];
@@ -39,33 +55,24 @@
   function buildIcon(index: number) {
     return leaflet.divIcon({
       className: "",
-      html: `<div style="
-        width:28px;height:28px;
-        background:#4f46e5;
-        border:2px solid white;
-        border-radius:50%;
-        display:flex;align-items:center;justify-content:center;
-        color:white;font-size:11px;font-weight:700;
-        box-shadow:0 2px 6px rgba(0,0,0,.4);
-      ">${index + 1}</div>`,
-      iconSize: [28, 28],
-      iconAnchor: [14, 14],
+      html: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 32" width="24" height="32" style="filter:drop-shadow(0 2px 4px rgba(0,0,0,0.35))">
+        <path d="M12 0C5.4 0 0 5.4 0 12c0 9 12 20 12 20S24 21 24 12C24 5.4 18.6 0 12 0z" fill="#4f46e5"/>
+        <text x="12" y="15" text-anchor="middle" fill="white" font-size="10" font-weight="700" font-family="sans-serif">${index + 1}</text>
+      </svg>`,
+      iconSize: [24, 32],
+      iconAnchor: [12, 32],
     });
   }
 
   function buildReferenceIcon() {
     return leaflet.divIcon({
       className: "",
-      html: `<div style="
-        width:22px;height:22px;
-        background:#f59e0b;
-        border:2px solid white;
-        border-radius:50%;
-        display:flex;align-items:center;justify-content:center;
-        box-shadow:0 2px 6px rgba(0,0,0,.4);
-      "><svg viewBox="0 0 24 24" width="12" height="12" fill="white"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg></div>`,
-      iconSize: [22, 22],
-      iconAnchor: [11, 11],
+      html: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 32" width="24" height="32" style="filter:drop-shadow(0 2px 4px rgba(0,0,0,0.35))">
+        <path d="M12 0C5.4 0 0 5.4 0 12c0 9 12 20 12 20S24 21 24 12C24 5.4 18.6 0 12 0z" fill="#f59e0b"/>
+        <circle cx="12" cy="11" r="4" fill="white" opacity="0.9"/>
+      </svg>`,
+      iconSize: [24, 32],
+      iconAnchor: [12, 32],
     });
   }
 
@@ -147,12 +154,9 @@
 
     map = leaflet.map(mapContainer).setView([centerLat, centerLng], zoom);
 
-    leaflet
-      .tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 19,
-      })
+    const def = DEFAULT_TILE_LAYER;
+    activeTileLayer = leaflet
+      .tileLayer(def.url, { attribution: def.attribution, maxZoom: def.maxZoom })
       .addTo(map);
 
     if (editable) {
@@ -183,7 +187,25 @@
 </svelte:head>
 
 <div class="relative">
-  <div bind:this={mapContainer} style="height: {height};" class="w-full rounded-lg"></div>
+  <div class="relative isolate w-full rounded-lg overflow-hidden" style="height: {height};">
+    <div bind:this={mapContainer} class="w-full h-full"></div>
+
+    <!-- Tile layer toggle -->
+    <div class="absolute bottom-2 right-2 z-[1000] flex rounded-md overflow-hidden shadow-md">
+      {#each TILE_LAYERS as layer}
+        <button
+          type="button"
+          on:click={() => switchLayer(layer.id)}
+          class="px-2 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
+            {activeLayerId === layer.id
+              ? 'bg-indigo-600 text-white'
+              : 'bg-white text-gray-700 hover:bg-gray-50'}"
+        >
+          {layer.label}
+        </button>
+      {/each}
+    </div>
+  </div>
 
   {#if editable}
     <div class="mt-2 flex items-center justify-between text-xs text-gray-500">

--- a/src/lib/components/WaypointMap.svelte
+++ b/src/lib/components/WaypointMap.svelte
@@ -187,32 +187,21 @@
 </svelte:head>
 
 <div class="relative">
-  <div class="relative isolate w-full rounded-lg overflow-hidden" style="height: {height};">
+  <div class="isolate w-full rounded-lg overflow-hidden" style="height: {height};">
     <div bind:this={mapContainer} class="w-full h-full"></div>
-
-    <!-- Tile layer toggle -->
-    <div class="absolute bottom-2 right-2 z-[1000] flex rounded-md overflow-hidden shadow-md">
-      {#each TILE_LAYERS as layer}
-        <button
-          type="button"
-          on:click={() => switchLayer(layer.id)}
-          class="px-2 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
-            {activeLayerId === layer.id
-              ? 'bg-indigo-600 text-white'
-              : 'bg-white text-gray-700 hover:bg-gray-50'}"
-        >
-          {layer.label}
-        </button>
-      {/each}
-    </div>
   </div>
 
-  {#if editable}
-    <div class="mt-2 flex items-center justify-between text-xs text-gray-500">
-      <span
+  <div class="mt-1.5 flex items-center justify-between">
+    {#if editable}
+      <span class="text-xs text-gray-500"
         >Click map to add waypoints &bull; Right-click a marker to remove &bull; Drag to reposition</span
       >
-      {#if waypoints.length > 0}
+    {:else}
+      <span></span>
+    {/if}
+
+    <div class="flex items-center gap-2">
+      {#if editable && waypoints.length > 0}
         <button
           type="button"
           on:click={() => {
@@ -220,13 +209,29 @@
             emitChange();
             redraw();
           }}
-          class="text-red-500 hover:text-red-700 font-medium"
+          class="text-xs text-red-500 hover:text-red-700 font-medium"
         >
           Clear all
         </button>
       {/if}
+
+      <!-- Tile layer toggle -->
+      <div class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
+        {#each TILE_LAYERS as layer}
+          <button
+            type="button"
+            on:click={() => switchLayer(layer.id)}
+            class="px-2.5 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
+              {activeLayerId === layer.id
+                ? 'bg-indigo-600 text-white'
+                : 'bg-white text-gray-600 hover:bg-gray-50'}"
+          >
+            {layer.label}
+          </button>
+        {/each}
+      </div>
     </div>
-  {/if}
+  </div>
 </div>
 
 <style>

--- a/src/lib/components/WaypointMap.svelte
+++ b/src/lib/components/WaypointMap.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { TILE_LAYERS, DEFAULT_TILE_LAYER, type TileLayerId } from "$lib/utils/map-tiles";
+  import { TILE_LAYERS, DEFAULT_TILE_LAYER, getTileLayer, type TileLayerId } from "$lib/utils/map-tiles";
 
   type Waypoint = {
     lat: number;
@@ -37,7 +37,7 @@
 
   function switchLayer(id: TileLayerId) {
     if (!map || !leaflet || id === activeLayerId) return;
-    const def = TILE_LAYERS.find((t) => t.id === id)!;
+    const def = getTileLayer(id);;
     if (activeTileLayer) {
       activeTileLayer.remove();
     }
@@ -216,10 +216,11 @@
       {/if}
 
       <!-- Tile layer toggle -->
-      <div class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
+      <div role="group" aria-label="Map tile layer" class="flex rounded-md overflow-hidden border border-gray-200 shadow-sm">
         {#each TILE_LAYERS as layer}
           <button
             type="button"
+            aria-pressed={activeLayerId === layer.id}
             on:click={() => switchLayer(layer.id)}
             class="px-2.5 py-1 text-xs font-medium border-r border-gray-200 last:border-r-0 transition-colors
               {activeLayerId === layer.id

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -48,7 +48,7 @@ export const SECURITY_HEADERS: Record<string, string> = {
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' https://app.termly.io https://www.googletagmanager.com https://pagead2.googlesyndication.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://ep2.adtrafficquality.google https://static.cloudflareinsights.com",
     "style-src 'self' 'unsafe-inline' https://unpkg.com",
-    "img-src 'self' blob: data: https://files.adventurespark.org https://*.tile.openstreetmap.org https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://ep1.adtrafficquality.google",
+    "img-src 'self' blob: data: https://files.adventurespark.org https://*.tile.openstreetmap.org https://*.tile.opentopomap.org https://server.arcgisonline.com https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://ep1.adtrafficquality.google",
     "connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://pagead2.googlesyndication.com https://ep1.adtrafficquality.google https://app.termly.io https://us.consent.api.termly.io",
     "frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://ep2.adtrafficquality.google https://www.google.com",
     "font-src 'self'",

--- a/src/lib/utils/map-tiles.ts
+++ b/src/lib/utils/map-tiles.ts
@@ -1,14 +1,12 @@
-export type TileLayerId = "street" | "topo" | "esri-topo" | "satellite";
-
-export interface TileLayer {
-  id: TileLayerId;
+interface TileLayerDef {
+  id: string;
   label: string;
   url: string;
   attribution: string;
   maxZoom: number;
 }
 
-export const TILE_LAYERS: TileLayer[] = [
+export const TILE_LAYERS = [
   {
     id: "street",
     label: "Street",
@@ -37,7 +35,17 @@ export const TILE_LAYERS: TileLayer[] = [
     attribution: "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
     maxZoom: 18,
   },
+] as const satisfies readonly TileLayerDef[];
 
-];
+export type TileLayerId = (typeof TILE_LAYERS)[number]["id"];
+export type TileLayer = (typeof TILE_LAYERS)[number];
+
+export function getTileLayer(id: TileLayerId): TileLayer {
+  const layer = TILE_LAYERS.find((t) => t.id === id);
+  if (!layer) {
+    throw new Error(`Unknown tile layer id: ${id}`);
+  }
+  return layer as TileLayer;
+}
 
 export const DEFAULT_TILE_LAYER = TILE_LAYERS[0];

--- a/src/lib/utils/map-tiles.ts
+++ b/src/lib/utils/map-tiles.ts
@@ -1,0 +1,43 @@
+export type TileLayerId = "street" | "topo" | "esri-topo" | "satellite";
+
+export interface TileLayer {
+  id: TileLayerId;
+  label: string;
+  url: string;
+  attribution: string;
+  maxZoom: number;
+}
+
+export const TILE_LAYERS: TileLayer[] = [
+  {
+    id: "street",
+    label: "Street",
+    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    maxZoom: 19,
+  },
+  {
+    id: "topo",
+    label: "Topo",
+    url: "https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
+    attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a>',
+    maxZoom: 17,
+  },
+  {
+    id: "esri-topo",
+    label: "ESRI Topo",
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+    attribution: "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+    maxZoom: 18,
+  },
+  {
+    id: "satellite",
+    label: "Satellite",
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    attribution: "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+    maxZoom: 18,
+  },
+
+];
+
+export const DEFAULT_TILE_LAYER = TILE_LAYERS[0];


### PR DESCRIPTION
This pull request adds support for switching between multiple map tile layers (such as street, topo, and satellite) in all map components, and updates the map marker icons to use consistent SVG-based designs. It also updates security settings to allow loading tiles from new sources. The most important changes are grouped below.

**Map Layer Switching and Tile Layer Abstraction:**

* Introduced a new `map-tiles.ts` utility defining available map tile layers (`TILE_LAYERS`), their metadata, and a type-safe `TileLayerId` for easy integration and switching between street, topo, ESRI topo, and satellite layers. (`[src/lib/utils/map-tiles.tsR1-R43](diffhunk://#diff-d8c6c08ae49bc9043314e9b7a58d5f9c2e51cc982c1989e0611116484164577bR1-R43)`)
* Refactored `ListingMap.svelte`, `LocationMap.svelte`, and `WaypointMap.svelte` to support dynamic tile layer switching via a UI button group, using the new `switchLayer` function and tracking the active layer. (`[[1]](diffhunk://#diff-22a653bf83d28c9a830e0d7ee252245451e98ed5d9f582cd6a27bb28e8dbda82R4)`, `[[2]](diffhunk://#diff-22a653bf83d28c9a830e0d7ee252245451e98ed5d9f582cd6a27bb28e8dbda82R26-R55)`, `[[3]](diffhunk://#diff-22a653bf83d28c9a830e0d7ee252245451e98ed5d9f582cd6a27bb28e8dbda82L72-R94)`, `[[4]](diffhunk://#diff-22a653bf83d28c9a830e0d7ee252245451e98ed5d9f582cd6a27bb28e8dbda82L103-R138)`, `[[5]](diffhunk://#diff-adf22a2f0b265e3d2804d26e686d4805049d6d2193f7d69218df0df7c2605af9R4)`, `[[6]](diffhunk://#diff-adf22a2f0b265e3d2804d26e686d4805049d6d2193f7d69218df0df7c2605af9R14-R54)`, `[[7]](diffhunk://#diff-adf22a2f0b265e3d2804d26e686d4805049d6d2193f7d69218df0df7c2605af9L46-R70)`, `[[8]](diffhunk://#diff-adf22a2f0b265e3d2804d26e686d4805049d6d2193f7d69218df0df7c2605af9L60-R102)`, `[[9]](diffhunk://#diff-c983b18f4bc08488eff95b576b354d635966e19ea30115980db8a449d7ea9b68R3)`, `[[10]](diffhunk://#diff-c983b18f4bc08488eff95b576b354d635966e19ea30115980db8a449d7ea9b68R35-R49)`, `[[11]](diffhunk://#diff-c983b18f4bc08488eff95b576b354d635966e19ea30115980db8a449d7ea9b68L150-R159)`, `[[12]](diffhunk://#diff-c983b18f4bc08488eff95b576b354d635966e19ea30115980db8a449d7ea9b68L186-R208)`)

**Map Marker Icon Improvements:**

* Updated marker icons in all map components to use SVG graphics for a unified, modern look, replacing previous HTML/CSS-based markers. This includes numbered waypoint markers and distinct reference markers. (`[[1]](diffhunk://#diff-22a653bf83d28c9a830e0d7ee252245451e98ed5d9f582cd6a27bb28e8dbda82R26-R55)`, `[[2]](diffhunk://#diff-adf22a2f0b265e3d2804d26e686d4805049d6d2193f7d69218df0df7c2605af9R14-R54)`, `[[3]](diffhunk://#diff-adf22a2f0b265e3d2804d26e686d4805049d6d2193f7d69218df0df7c2605af9L46-R70)`, `[[4]](diffhunk://#diff-c983b18f4bc08488eff95b576b354d635966e19ea30115980db8a449d7ea9b68L42-R75)`)

**Security and Asset Loading:**

* Expanded the `img-src` Content Security Policy in `security.ts` to allow loading tiles from OpenTopoMap and ESRI servers, supporting the new tile layers. (`[src/lib/security.tsL51-R51](diffhunk://#diff-7eac64e3da433fe411105a67a05c2c2cf2d857a22b73a1694ae3ad7dd89f905bL51-R51)`)

These changes collectively provide users with more map visualization options and a more polished map UI.