### PR TITLE
Run DB migrations in preview workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -10,6 +10,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     environment: preview
+    needs: migrate
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -58,10 +58,34 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  migrate:
+    name: Run DB migrations
+    runs-on: ubuntu-latest
+    environment: preview
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migrations
+        run: npm run migrate all
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
   deploy:
     name: Deploy to Cloudflare Pages (preview)
     runs-on: ubuntu-latest
     environment: preview
+    needs: migrate
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -86,7 +86,7 @@ jobs:
     name: Deploy to Cloudflare Pages (preview)
     runs-on: ubuntu-latest
     environment: preview
-    needs: migrate
+    needs: [migrate, test]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add a new `migrate` job to the preview GitHub Actions workflow that checks out code, sets up Node.js 20, installs dependencies, and runs `npm run migrate all` using the `DATABASE_URL` secret. The `deploy` job now depends on `migrate` (`needs: migrate`) so migrations run and complete before preview deployment.