### PR TITLE
Preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -86,7 +86,7 @@ jobs:
     name: Deploy to Cloudflare Pages (preview)
     runs-on: ubuntu-latest
     environment: preview
-    needs: [migrate, test]
+    needs: [migrate]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -19,7 +19,8 @@ async function authenticate(
 ) {
   // POST credentials — the server sets httpOnly session cookies on this domain
   const response = await page.request.post('/api/auth/test-session', {
-    data: { email, password },
+    data: JSON.stringify({ email, password }),
+    headers: { 'content-type': 'application/json' },
   });
 
   if (!response.ok()) {
@@ -35,20 +36,26 @@ async function authenticate(
   await page.context().storageState({ path: storageFile });
 }
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Required env var ${name} is not set. ` +
+        'Add it to .env.test locally or as a GitHub Actions secret in the preview environment.'
+    );
+  }
+  return value;
+}
+
 setup('authenticate as regular user', async ({ page }) => {
-  await authenticate(
-    page,
-    process.env.TEST_USER_EMAIL!,
-    process.env.TEST_USER_PASSWORD!,
-    userFile
-  );
+  await authenticate(page, requireEnv('TEST_USER_EMAIL'), requireEnv('TEST_USER_PASSWORD'), userFile);
 });
 
 setup('authenticate as admin', async ({ page }) => {
   await authenticate(
     page,
-    process.env.TEST_ADMIN_EMAIL!,
-    process.env.TEST_ADMIN_PASSWORD!,
+    requireEnv('TEST_ADMIN_EMAIL'),
+    requireEnv('TEST_ADMIN_PASSWORD'),
     adminFile
   );
 });

--- a/e2e/login.anon.spec.ts
+++ b/e2e/login.anon.spec.ts
@@ -6,7 +6,7 @@ test.describe('Login page – anonymous', () => {
     const response = await request.get('/login', { maxRedirects: 0 });
     expect(response.status()).toBe(302);
     const location = response.headers()['location'] ?? '';
-    expect(location).not.toMatch(/localhost/);
+    expect(location).toMatch(/workos\.com|authkit\.app/);
     expect(location.length).toBeGreaterThan(0);
   });
 
@@ -33,9 +33,9 @@ test.describe('Login page – anonymous', () => {
     await expect(button).toBeVisible();
     // Clicking it navigates away from localhost (to WorkOS hosted UI)
     await Promise.all([
-      page.waitForURL((url) => !url.hostname.includes('localhost')),
+      page.waitForURL((url) => /workos\.com|authkit\.app/.test(url.hostname)),
       button.click(),
     ]);
-    await expect(page).not.toHaveURL(/localhost/);
+    await expect(page).toHaveURL(/workos\.com|authkit\.app/);
   });
 });

--- a/e2e/public.anon.spec.ts
+++ b/e2e/public.anon.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+async function expectRedirectsToLogin(request: APIRequestContext, path: string) {
+  const response = await request.get(path, { maxRedirects: 0 });
+  expect(response.status()).toBe(302);
+  expect(response.headers()['location']).toMatch('/login');
+}
 
 test.describe('Anonymous user – public pages', () => {
   test('homepage loads and shows content', async ({ page }) => {
@@ -24,23 +30,19 @@ test.describe('Anonymous user – public pages', () => {
     await expect(page.locator('h2').filter({ hasText: 'The Scout Motto: Be Prepared' })).toBeVisible();
   });
 
-  test('/submit redirects anonymous users to /login', async ({ page }) => {
-    await page.goto('/submit');
-    await expect(page).toHaveURL(/\/login/);
+  test('/submit redirects anonymous users to /login', async ({ request }) => {
+    await expectRedirectsToLogin(request, '/submit');
   });
 
-  test('/favorites redirects anonymous users to /login', async ({ page }) => {
-    await page.goto('/favorites');
-    await expect(page).toHaveURL(/\/login/);
+  test('/favorites redirects anonymous users to /login', async ({ request }) => {
+    await expectRedirectsToLogin(request, '/favorites');
   });
 
-  test('/profile redirects anonymous users to /login', async ({ page }) => {
-    await page.goto('/profile');
-    await expect(page).toHaveURL(/\/login/);
+  test('/profile redirects anonymous users to /login', async ({ request }) => {
+    await expectRedirectsToLogin(request, '/profile');
   });
 
-  test('/admin redirects anonymous users to /login', async ({ page }) => {
-    await page.goto('/admin');
-    await expect(page).toHaveURL(/\/login/);
+  test('/admin redirects anonymous users to /login', async ({ request }) => {
+    await expectRedirectsToLogin(request, '/admin');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "leaflet": "^1.9.4",
         "lucide-svelte": "^0.575.0",
         "marked": "^18.0.1",
-        "obscenity": "^0.4.5"
+        "obscenity": "^0.4.5",
+        "sanitize-html": "^2.17.3"
       },
       "devDependencies": {
         "@ernane/svelte-star-rating": "^1.1.9",
@@ -37,6 +38,7 @@
         "@testing-library/svelte": "^5.2.9",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^22",
+        "@types/sanitize-html": "^2.16.1",
         "@typescript-eslint/eslint-plugin": "^8.55.0",
         "@typescript-eslint/parser": "^8.55.0",
         "@vitest/ui": "^4.1.0",
@@ -8073,6 +8075,49 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@types/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -10594,7 +10639,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11850,6 +11894,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -12763,7 +12816,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -13019,6 +13071,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
     },
     "node_modules/parseley": {
       "version": "0.12.1",
@@ -13291,7 +13349,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -13431,7 +13488,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14294,6 +14350,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
+      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -14545,7 +14646,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@testing-library/svelte": "^5.2.9",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^22",
+    "@types/sanitize-html": "^2.16.1",
     "@typescript-eslint/eslint-plugin": "^8.55.0",
     "@typescript-eslint/parser": "^8.55.0",
     "@vitest/ui": "^4.1.0",
@@ -85,6 +86,7 @@
     "leaflet": "^1.9.4",
     "lucide-svelte": "^0.575.0",
     "marked": "^18.0.1",
-    "obscenity": "^0.4.5"
+    "obscenity": "^0.4.5",
+    "sanitize-html": "^2.17.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import { config } from 'dotenv';
+
+config({ path: '.env.test' });
 
 export default defineConfig({
   testDir: './e2e',

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -179,6 +179,11 @@ const securityHandle: Handle = async ({ event, resolve }) => {
   if (!["GET", "HEAD", "OPTIONS"].includes(event.request.method)) {
     response.headers.set("Cache-Control", "no-store");
   }
+  // HTML pages must not be cached — hashed asset filenames break after a new
+  // deploy because Cloudflare Pages doesn't keep old deployments' files alive.
+  if (response.headers.get("content-type")?.includes("text/html")) {
+    response.headers.set("Cache-Control", "no-store");
+  }
   return response;
 };
 

--- a/src/lib/storage/blob.ts
+++ b/src/lib/storage/blob.ts
@@ -3,7 +3,6 @@ import {
   PutObjectCommand,
   DeleteObjectCommand,
   ListObjectsV2Command,
-  CopyObjectCommand,
   type _Object,
 } from "@aws-sdk/client-s3";
 import { error } from "@sveltejs/kit";
@@ -123,20 +122,6 @@ export async function deleteFile(pathname: string): Promise<void> {
       Key: toKey(pathname),
     })
   );
-}
-
-export async function moveFile(sourceKey: string, destKey: string): Promise<string> {
-  const client = getS3Client();
-  const bucket = getBucketName();
-  const src = toKey(sourceKey);
-  const dst = toKey(destKey);
-
-  await client.send(
-    new CopyObjectCommand({ Bucket: bucket, CopySource: `${bucket}/${src}`, Key: dst })
-  );
-  await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: src }));
-
-  return getPublicUrl(dst);
 }
 
 export async function listFiles(prefix: string): Promise<_Object[]> {

--- a/src/lib/storage/blob.ts
+++ b/src/lib/storage/blob.ts
@@ -3,6 +3,7 @@ import {
   PutObjectCommand,
   DeleteObjectCommand,
   ListObjectsV2Command,
+  CopyObjectCommand,
   type _Object,
 } from "@aws-sdk/client-s3";
 import { error } from "@sveltejs/kit";
@@ -122,6 +123,20 @@ export async function deleteFile(pathname: string): Promise<void> {
       Key: toKey(pathname),
     })
   );
+}
+
+export async function moveFile(sourceKey: string, destKey: string): Promise<string> {
+  const client = getS3Client();
+  const bucket = getBucketName();
+  const src = toKey(sourceKey);
+  const dst = toKey(destKey);
+
+  await client.send(
+    new CopyObjectCommand({ Bucket: bucket, CopySource: `${bucket}/${src}`, Key: dst })
+  );
+  await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: src }));
+
+  return getPublicUrl(dst);
 }
 
 export async function listFiles(prefix: string): Promise<_Object[]> {

--- a/src/lib/storage/blob.ts
+++ b/src/lib/storage/blob.ts
@@ -127,13 +127,21 @@ export async function deleteFile(pathname: string): Promise<void> {
 export async function listFiles(prefix: string): Promise<_Object[]> {
   const client = getS3Client();
   const bucket = getBucketName();
+  const key = toKey(prefix);
+  const all: _Object[] = [];
+  let continuationToken: string | undefined;
 
-  const response = await client.send(
-    new ListObjectsV2Command({
-      Bucket: bucket,
-      Prefix: toKey(prefix),
-    })
-  );
+  do {
+    const response = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: key,
+        ContinuationToken: continuationToken,
+      })
+    );
+    all.push(...(response.Contents ?? []));
+    continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+  } while (continuationToken);
 
-  return response.Contents ?? [];
+  return all;
 }

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,0 +1,7 @@
+<slot />
+
+<style>
+  :global(body) {
+    background-color: #0c0f0a;
+  }
+</style>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -273,7 +273,4 @@
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
     background-size: 200px 200px;
   }
-  :global(body) {
-    background-color: #0c0f0a;
-  }
 </style>

--- a/src/routes/admin/blog/[slug]/edit/+page.svelte
+++ b/src/routes/admin/blog/[slug]/edit/+page.svelte
@@ -14,6 +14,7 @@
   let seriesOrder = "";
   let coverImageUrl = "";
   let coverUploading = false;
+  let inlineImageUploading = false;
   let saving = false;
   let deleting = false;
   let errorMsg = "";
@@ -88,6 +89,31 @@
       const maxOrder = sd.posts.reduce((m: number, p: any) => Math.max(m, p.seriesOrder ?? 0), 0);
       seriesOrder = String(maxOrder + 1);
     }
+  }
+
+  async function onInlineImageChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    inlineImageUploading = true;
+    const fd = new FormData();
+    fd.append("file", file);
+    const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
+    inlineImageUploading = false;
+    if (res.ok) {
+      const d = await res.json();
+      const md = `![image](${d.url})`;
+      const start = editorEl.selectionStart ?? body.length;
+      const end = editorEl.selectionEnd ?? body.length;
+      body = body.slice(0, start) + md + body.slice(end);
+      requestAnimationFrame(() => {
+        editorEl.selectionStart = editorEl.selectionEnd = start + md.length;
+        editorEl.focus();
+      });
+    } else {
+      errorMsg = "Failed to upload image";
+    }
+    input.value = "";
   }
 
   async function onCoverFileChange(e: Event) {
@@ -329,8 +355,15 @@
         <div class="border border-white/10 rounded-lg overflow-hidden">
           <!-- Panel headers -->
           <div class="grid grid-cols-2 border-b border-white/10">
-            <div class="px-4 py-2 border-r border-white/10 bg-white/[0.03]">
+            <div class="px-4 py-2 border-r border-white/10 bg-white/[0.03] flex items-center justify-between">
               <span class="text-xs font-semibold text-stone-500 uppercase tracking-wider">Markdown</span>
+              <label class="flex items-center gap-1.5 text-xs text-stone-500 hover:text-stone-300 cursor-pointer transition-colors {inlineImageUploading ? 'opacity-50 pointer-events-none' : ''}">
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {inlineImageUploading ? "Uploading…" : "Insert image"}
+                <input type="file" accept="image/jpeg,image/jpg,image/png,image/webp" on:change={onInlineImageChange} class="sr-only" />
+              </label>
             </div>
             <div class="px-4 py-2 bg-white/[0.02]">
               <span class="text-xs font-semibold text-stone-500 uppercase tracking-wider">Preview</span>

--- a/src/routes/admin/blog/[slug]/edit/+page.svelte
+++ b/src/routes/admin/blog/[slug]/edit/+page.svelte
@@ -148,7 +148,7 @@
     errorMsg = "";
     saving = true;
 
-    const res = await fetch(`/api/posts/${data.post.slug}`, {
+    const res = await fetch(`/api/posts/${data.post.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -176,7 +176,7 @@
   async function deletePost() {
     if (!confirm("Delete this post? This cannot be undone.")) return;
     deleting = true;
-    const res = await fetch(`/api/posts/${data.post.slug}`, { method: "DELETE" });
+    const res = await fetch(`/api/posts/${data.post.id}`, { method: "DELETE" });
     deleting = false;
     if (res.ok) {
       goto("/admin/blog");

--- a/src/routes/admin/blog/[slug]/edit/+page.svelte
+++ b/src/routes/admin/blog/[slug]/edit/+page.svelte
@@ -96,24 +96,30 @@
     const file = input.files?.[0];
     if (!file) return;
     inlineImageUploading = true;
-    const fd = new FormData();
-    fd.append("file", file);
-    const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
-    inlineImageUploading = false;
-    if (res.ok) {
-      const d = await res.json();
-      const md = `![image](${d.url})`;
-      const start = editorEl.selectionStart ?? body.length;
-      const end = editorEl.selectionEnd ?? body.length;
-      body = body.slice(0, start) + md + body.slice(end);
-      requestAnimationFrame(() => {
-        editorEl.selectionStart = editorEl.selectionEnd = start + md.length;
-        editorEl.focus();
-      });
-    } else {
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      fd.append("slug", data.post.slug);
+      const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
+      if (res.ok) {
+        const d = await res.json();
+        const md = `![image](${d.url})`;
+        const start = editorEl.selectionStart ?? body.length;
+        const end = editorEl.selectionEnd ?? body.length;
+        body = body.slice(0, start) + md + body.slice(end);
+        requestAnimationFrame(() => {
+          editorEl.selectionStart = editorEl.selectionEnd = start + md.length;
+          editorEl.focus();
+        });
+      } else {
+        errorMsg = "Failed to upload image";
+      }
+    } catch {
       errorMsg = "Failed to upload image";
+    } finally {
+      inlineImageUploading = false;
+      input.value = "";
     }
-    input.value = "";
   }
 
   async function onCoverFileChange(e: Event) {
@@ -123,6 +129,7 @@
     coverUploading = true;
     const fd = new FormData();
     fd.append("file", file);
+    fd.append("slug", data.post.slug);
     const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
     coverUploading = false;
     if (res.ok) {

--- a/src/routes/admin/blog/[slug]/edit/+page.svelte
+++ b/src/routes/admin/blog/[slug]/edit/+page.svelte
@@ -179,7 +179,7 @@
     const res = await fetch(`/api/posts/${data.post.id}`, { method: "DELETE" });
     deleting = false;
     if (res.ok) {
-      goto("/admin/blog");
+      goto("/admin/blog", { invalidateAll: true });
     } else {
       errorMsg = "Failed to delete post";
     }

--- a/src/routes/admin/blog/[slug]/edit/+page.svelte
+++ b/src/routes/admin/blog/[slug]/edit/+page.svelte
@@ -99,7 +99,7 @@
     try {
       const fd = new FormData();
       fd.append("file", file);
-      fd.append("slug", data.post.slug);
+      fd.append("postId", data.post.id);
       const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
       if (res.ok) {
         const d = await res.json();
@@ -129,7 +129,7 @@
     coverUploading = true;
     const fd = new FormData();
     fd.append("file", file);
-    fd.append("slug", data.post.slug);
+    fd.append("postId", data.post.id);
     const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
     coverUploading = false;
     if (res.ok) {

--- a/src/routes/admin/blog/new/+page.server.ts
+++ b/src/routes/admin/blog/new/+page.server.ts
@@ -1,11 +1,22 @@
 import { requireAdmin } from "$lib/auth/middleware";
+import { db } from "$lib/db";
+import { posts } from "$lib/db/schemas";
+import { generateUniqueSlug } from "$lib/server/slug";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async (event) => {
   requireAdmin(event);
 
+  // Create an empty draft immediately so uploads have a stable post ID before the form is saved.
+  // If the user cancels, the Cancel button deletes this draft and its R2 objects.
+  const slug = await generateUniqueSlug("Untitled", "post");
+  const [draft] = await db
+    .insert(posts)
+    .values({ title: "Untitled", slug, body: "", status: "draft", authorId: event.locals.user!.id })
+    .returning();
+
   const res = await event.fetch("/api/series");
   const allSeries = await res.json();
 
-  return { allSeries };
+  return { draft, allSeries };
 };

--- a/src/routes/admin/blog/new/+page.svelte
+++ b/src/routes/admin/blog/new/+page.svelte
@@ -129,7 +129,7 @@
     errorMsg = "";
     saving = true;
 
-    const res = await fetch(`/api/posts/${data.draft.slug}`, {
+    const res = await fetch(`/api/posts/${data.draft.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -158,8 +158,8 @@
     errorMsg = "";
     canceling = true;
     try {
-      const res = await fetch(`/api/posts/${data.draft.slug}`, { method: "DELETE" });
-      if (res.ok) {
+      const res = await fetch(`/api/posts/${data.draft.id}`, { method: "DELETE" });
+      if (res.ok || res.status === 404) {
         await goto("/admin/blog");
       } else {
         errorMsg = "Failed to delete draft. Please try again.";

--- a/src/routes/admin/blog/new/+page.svelte
+++ b/src/routes/admin/blog/new/+page.svelte
@@ -13,6 +13,7 @@
   let seriesOrder = "";
   let coverImageUrl = "";
   let coverUploading = false;
+  let inlineImageUploading = false;
   let saving = false;
   let errorMsg = "";
   let renderedPreview = "";
@@ -68,6 +69,31 @@
       const maxOrder = sd.posts.reduce((m: number, p: any) => Math.max(m, p.seriesOrder ?? 0), 0);
       seriesOrder = String(maxOrder + 1);
     }
+  }
+
+  async function onInlineImageChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    inlineImageUploading = true;
+    const fd = new FormData();
+    fd.append("file", file);
+    const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
+    inlineImageUploading = false;
+    if (res.ok) {
+      const d = await res.json();
+      const md = `![image](${d.url})`;
+      const start = editorEl.selectionStart ?? body.length;
+      const end = editorEl.selectionEnd ?? body.length;
+      body = body.slice(0, start) + md + body.slice(end);
+      requestAnimationFrame(() => {
+        editorEl.selectionStart = editorEl.selectionEnd = start + md.length;
+        editorEl.focus();
+      });
+    } else {
+      errorMsg = "Failed to upload image";
+    }
+    input.value = "";
   }
 
   async function onCoverFileChange(e: Event) {
@@ -298,8 +324,15 @@
         <div class="border border-white/10 rounded-lg overflow-hidden">
           <!-- Panel headers -->
           <div class="grid grid-cols-2 border-b border-white/10">
-            <div class="px-4 py-2 border-r border-white/10 bg-white/[0.03]">
+            <div class="px-4 py-2 border-r border-white/10 bg-white/[0.03] flex items-center justify-between">
               <span class="text-xs font-semibold text-stone-500 uppercase tracking-wider">Markdown</span>
+              <label class="flex items-center gap-1.5 text-xs text-stone-500 hover:text-stone-300 cursor-pointer transition-colors {inlineImageUploading ? 'opacity-50 pointer-events-none' : ''}">
+                <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                {inlineImageUploading ? "Uploading…" : "Insert image"}
+                <input type="file" accept="image/jpeg,image/jpg,image/png,image/webp" on:change={onInlineImageChange} class="sr-only" />
+              </label>
             </div>
             <div class="px-4 py-2 bg-white/[0.02]">
               <span class="text-xs font-semibold text-stone-500 uppercase tracking-wider">Preview</span>

--- a/src/routes/admin/blog/new/+page.svelte
+++ b/src/routes/admin/blog/new/+page.svelte
@@ -76,24 +76,29 @@
     const file = input.files?.[0];
     if (!file) return;
     inlineImageUploading = true;
-    const fd = new FormData();
-    fd.append("file", file);
-    const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
-    inlineImageUploading = false;
-    if (res.ok) {
-      const d = await res.json();
-      const md = `![image](${d.url})`;
-      const start = editorEl.selectionStart ?? body.length;
-      const end = editorEl.selectionEnd ?? body.length;
-      body = body.slice(0, start) + md + body.slice(end);
-      requestAnimationFrame(() => {
-        editorEl.selectionStart = editorEl.selectionEnd = start + md.length;
-        editorEl.focus();
-      });
-    } else {
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
+      if (res.ok) {
+        const d = await res.json();
+        const md = `![image](${d.url})`;
+        const start = editorEl.selectionStart ?? body.length;
+        const end = editorEl.selectionEnd ?? body.length;
+        body = body.slice(0, start) + md + body.slice(end);
+        requestAnimationFrame(() => {
+          editorEl.selectionStart = editorEl.selectionEnd = start + md.length;
+          editorEl.focus();
+        });
+      } else {
+        errorMsg = "Failed to upload image";
+      }
+    } catch {
       errorMsg = "Failed to upload image";
+    } finally {
+      inlineImageUploading = false;
+      input.value = "";
     }
-    input.value = "";
   }
 
   async function onCoverFileChange(e: Event) {

--- a/src/routes/admin/blog/new/+page.svelte
+++ b/src/routes/admin/blog/new/+page.svelte
@@ -156,8 +156,12 @@
 
   async function cancel() {
     canceling = true;
-    await fetch(`/api/posts/${data.draft.slug}`, { method: "DELETE" });
-    goto("/admin/blog");
+    try {
+      await fetch(`/api/posts/${data.draft.slug}`, { method: "DELETE" });
+      await goto("/admin/blog");
+    } catch {
+      await goto("/admin/blog");
+    }
   }
 </script>
 
@@ -170,9 +174,9 @@
 <div class="relative z-10 min-h-screen pt-16 pb-16">
   <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center gap-3 mb-8">
-      <a href="/admin/blog" class="text-sm text-stone-500 hover:text-stone-300 transition-colors">
+      <button type="button" on:click={cancel} class="text-sm text-stone-500 hover:text-stone-300 transition-colors">
         ← Blog
-      </a>
+      </button>
       <span class="text-stone-700">/</span>
       <h1 class="text-xl font-bold text-stone-100">New Post</h1>
     </div>

--- a/src/routes/admin/blog/new/+page.svelte
+++ b/src/routes/admin/blog/new/+page.svelte
@@ -155,12 +155,19 @@
   }
 
   async function cancel() {
+    errorMsg = "";
     canceling = true;
     try {
-      await fetch(`/api/posts/${data.draft.slug}`, { method: "DELETE" });
-      await goto("/admin/blog");
+      const res = await fetch(`/api/posts/${data.draft.slug}`, { method: "DELETE" });
+      if (res.ok) {
+        await goto("/admin/blog");
+      } else {
+        errorMsg = "Failed to delete draft. Please try again.";
+        canceling = false;
+      }
     } catch {
-      await goto("/admin/blog");
+      errorMsg = "Failed to delete draft. Please try again.";
+      canceling = false;
     }
   }
 </script>

--- a/src/routes/admin/blog/new/+page.svelte
+++ b/src/routes/admin/blog/new/+page.svelte
@@ -15,6 +15,7 @@
   let coverUploading = false;
   let inlineImageUploading = false;
   let saving = false;
+  let canceling = false;
   let errorMsg = "";
   let renderedPreview = "";
 
@@ -79,6 +80,7 @@
     try {
       const fd = new FormData();
       fd.append("file", file);
+      fd.append("postId", data.draft.id);
       const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
       if (res.ok) {
         const d = await res.json();
@@ -108,6 +110,7 @@
     coverUploading = true;
     const fd = new FormData();
     fd.append("file", file);
+    fd.append("postId", data.draft.id);
     const res = await fetch("/api/posts/cover", { method: "POST", body: fd });
     coverUploading = false;
     if (res.ok) {
@@ -126,8 +129,8 @@
     errorMsg = "";
     saving = true;
 
-    const res = await fetch("/api/posts", {
-      method: "POST",
+    const res = await fetch(`/api/posts/${data.draft.slug}`, {
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         title,
@@ -149,6 +152,12 @@
       const d = await res.json().catch(() => ({}));
       errorMsg = d.message ?? "Failed to save post";
     }
+  }
+
+  async function cancel() {
+    canceling = true;
+    await fetch(`/api/posts/${data.draft.slug}`, { method: "DELETE" });
+    goto("/admin/blog");
   }
 </script>
 
@@ -379,12 +388,14 @@
         >
           {saving ? "Saving…" : "Save Post"}
         </button>
-        <a
-          href="/admin/blog"
-          class="px-6 py-2.5 bg-white/5 border border-white/10 text-stone-300 text-sm font-semibold rounded-lg hover:bg-white/10 transition-colors"
+        <button
+          type="button"
+          on:click={cancel}
+          disabled={canceling}
+          class="px-6 py-2.5 bg-white/5 border border-white/10 text-stone-300 text-sm font-semibold rounded-lg hover:bg-white/10 disabled:opacity-50 transition-colors"
         >
-          Cancel
-        </a>
+          {canceling ? "Canceling…" : "Cancel"}
+        </button>
       </div>
     </div>
   </div>

--- a/src/routes/admin/featured/+page.svelte
+++ b/src/routes/admin/featured/+page.svelte
@@ -317,7 +317,4 @@
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
     background-size: 200px 200px;
   }
-  :global(body) {
-    background-color: #0c0f0a;
-  }
 </style>

--- a/src/routes/admin/image-flags/+page.svelte
+++ b/src/routes/admin/image-flags/+page.svelte
@@ -196,7 +196,4 @@
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
     background-size: 200px 200px;
   }
-  :global(body) {
-    background-color: #0c0f0a;
-  }
 </style>

--- a/src/routes/admin/moderation/+page.svelte
+++ b/src/routes/admin/moderation/+page.svelte
@@ -359,7 +359,4 @@
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
     background-size: 200px 200px;
   }
-  :global(body) {
-    background-color: #0c0f0a;
-  }
 </style>

--- a/src/routes/admin/types/+page.svelte
+++ b/src/routes/admin/types/+page.svelte
@@ -348,7 +348,4 @@
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
     background-size: 200px 200px;
   }
-  :global(body) {
-    background-color: #0c0f0a;
-  }
 </style>

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -237,7 +237,4 @@
     background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
     background-size: 200px 200px;
   }
-  :global(body) {
-    background-color: #0c0f0a;
-  }
 </style>

--- a/src/routes/api/auth/test-session/+server.ts
+++ b/src/routes/api/auth/test-session/+server.ts
@@ -13,8 +13,12 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
   }
 
   const body = await request.json().catch(() => null);
+  if (body === null) {
+    throw error(400, "Request body could not be parsed as JSON. Ensure Content-Type: application/json is set.");
+  }
   if (!body?.email || !body?.password) {
-    throw error(400, "email and password are required");
+    const missing = [!body.email && "email", !body.password && "password"].filter(Boolean).join(", ");
+    throw error(400, `Missing or empty credentials: ${missing}. Check TEST_USER_EMAIL / TEST_USER_PASSWORD / TEST_ADMIN_EMAIL / TEST_ADMIN_PASSWORD env vars.`);
   }
 
   const { accessToken, refreshToken } = await workosAuth.signIn(body.email, body.password);

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -3,10 +3,47 @@ import { requireAdmin } from "$lib/auth/middleware";
 import { db } from "$lib/db";
 import { posts, series } from "$lib/db/schemas";
 import { generateUniqueSlug } from "$lib/server/slug";
+import { moveFile } from "$lib/storage/blob";
 import { parseLimit, parseOffset } from "$lib/utils/pagination";
 import { error, json } from "@sveltejs/kit";
 import { and, count, desc, eq, inArray, max } from "drizzle-orm";
 import type { RequestHandler } from "./$types";
+
+// After a slug is known, move any images uploaded to posts/_draft/ into posts/{slug}/
+// and rewrite the URLs in the markdown body and cover URL.
+async function relocateDraftImages(
+  slug: string,
+  postBody: string,
+  coverImageUrl: string | null
+): Promise<{ body: string; coverImageUrl: string | null }> {
+  const draftPattern = /(https?:\/\/[^\s)"]+\/posts\/_draft\/[^\s)"]+)/g;
+
+  const allUrls = new Set<string>();
+  for (const [, url] of postBody.matchAll(draftPattern)) allUrls.add(url);
+  if (coverImageUrl?.includes("/posts/_draft/")) allUrls.add(coverImageUrl);
+
+  if (allUrls.size === 0) return { body: postBody, coverImageUrl };
+
+  const urlMap = new Map<string, string>();
+  await Promise.all(
+    [...allUrls].map(async (url) => {
+      const srcKey = new URL(url).pathname.replace(/^\/+/, "");
+      const filename = srcKey.split("/").pop()!;
+      const destKey = `posts/${slug}/${filename}`;
+      const newUrl = await moveFile(srcKey, destKey);
+      urlMap.set(url, newUrl);
+    })
+  );
+
+  let body = postBody;
+  let cover = coverImageUrl;
+  for (const [oldUrl, newUrl] of urlMap) {
+    body = body.split(oldUrl).join(newUrl);
+    if (cover === oldUrl) cover = newUrl;
+  }
+
+  return { body, coverImageUrl: cover };
+}
 
 export const GET: RequestHandler = async ({ url, locals }) => {
   const privileged = isPrivilegedUser(locals.user);
@@ -75,6 +112,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
   const slug = await generateUniqueSlug(title, "post");
 
+  const { body: finalBody, coverImageUrl: finalCoverImageUrl } = await relocateDraftImages(
+    slug,
+    postBody,
+    coverImageUrl || null
+  );
+
   // Auto-assign series order if a series is given but no order provided
   let resolvedOrder: number | null = null;
   if (seriesId) {
@@ -95,7 +138,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
       title,
       slug,
       excerpt: excerpt || null,
-      body: postBody,
+      body: finalBody,
       status: status || "draft",
       scheduledAt: scheduledAt ? new Date(scheduledAt) : null,
       publishedAt: status === "published" ? new Date() : null,
@@ -103,7 +146,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
       authorId: locals.user!.id,
       seriesId: seriesId || null,
       seriesOrder: resolvedOrder,
-      coverImageUrl: coverImageUrl || null,
+      coverImageUrl: finalCoverImageUrl,
     })
     .returning();
 

--- a/src/routes/api/posts/+server.ts
+++ b/src/routes/api/posts/+server.ts
@@ -3,47 +3,10 @@ import { requireAdmin } from "$lib/auth/middleware";
 import { db } from "$lib/db";
 import { posts, series } from "$lib/db/schemas";
 import { generateUniqueSlug } from "$lib/server/slug";
-import { moveFile } from "$lib/storage/blob";
 import { parseLimit, parseOffset } from "$lib/utils/pagination";
 import { error, json } from "@sveltejs/kit";
 import { and, count, desc, eq, inArray, max } from "drizzle-orm";
 import type { RequestHandler } from "./$types";
-
-// After a slug is known, move any images uploaded to posts/_draft/ into posts/{slug}/
-// and rewrite the URLs in the markdown body and cover URL.
-async function relocateDraftImages(
-  slug: string,
-  postBody: string,
-  coverImageUrl: string | null
-): Promise<{ body: string; coverImageUrl: string | null }> {
-  const draftPattern = /(https?:\/\/[^\s)"]+\/posts\/_draft\/[^\s)"]+)/g;
-
-  const allUrls = new Set<string>();
-  for (const [, url] of postBody.matchAll(draftPattern)) allUrls.add(url);
-  if (coverImageUrl?.includes("/posts/_draft/")) allUrls.add(coverImageUrl);
-
-  if (allUrls.size === 0) return { body: postBody, coverImageUrl };
-
-  const urlMap = new Map<string, string>();
-  await Promise.all(
-    [...allUrls].map(async (url) => {
-      const srcKey = new URL(url).pathname.replace(/^\/+/, "");
-      const filename = srcKey.split("/").pop()!;
-      const destKey = `posts/${slug}/${filename}`;
-      const newUrl = await moveFile(srcKey, destKey);
-      urlMap.set(url, newUrl);
-    })
-  );
-
-  let body = postBody;
-  let cover = coverImageUrl;
-  for (const [oldUrl, newUrl] of urlMap) {
-    body = body.split(oldUrl).join(newUrl);
-    if (cover === oldUrl) cover = newUrl;
-  }
-
-  return { body, coverImageUrl: cover };
-}
 
 export const GET: RequestHandler = async ({ url, locals }) => {
   const privileged = isPrivilegedUser(locals.user);
@@ -112,12 +75,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
   const slug = await generateUniqueSlug(title, "post");
 
-  const { body: finalBody, coverImageUrl: finalCoverImageUrl } = await relocateDraftImages(
-    slug,
-    postBody,
-    coverImageUrl || null
-  );
-
   // Auto-assign series order if a series is given but no order provided
   let resolvedOrder: number | null = null;
   if (seriesId) {
@@ -138,7 +95,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
       title,
       slug,
       excerpt: excerpt || null,
-      body: finalBody,
+      body: postBody,
       status: status || "draft",
       scheduledAt: scheduledAt ? new Date(scheduledAt) : null,
       publishedAt: status === "published" ? new Date() : null,
@@ -146,7 +103,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
       authorId: locals.user!.id,
       seriesId: seriesId || null,
       seriesOrder: resolvedOrder,
-      coverImageUrl: finalCoverImageUrl,
+      coverImageUrl: coverImageUrl || null,
     })
     .returning();
 

--- a/src/routes/api/posts/[slug]/+server.ts
+++ b/src/routes/api/posts/[slug]/+server.ts
@@ -151,8 +151,8 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 
   await db.delete(posts).where(eq(posts.id, post.id));
 
-  // Delete all R2 objects stored under posts/{slug}/
-  const objects = await listFiles(`posts/${post.slug}/`);
+  // Delete all R2 objects stored under posts/{id}/ (stable across slug renames)
+  const objects = await listFiles(`posts/${post.id}/`);
   const deletions = objects
     .filter((o) => o.Key)
     .map((o) => deleteFile(o.Key!));

--- a/src/routes/api/posts/[slug]/+server.ts
+++ b/src/routes/api/posts/[slug]/+server.ts
@@ -153,13 +153,11 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
 
   // Delete all R2 objects stored under posts/{id}/ (stable across slug renames)
   const objects = await listFiles(`posts/${post.id}/`);
-  const deletions = objects
-    .filter((o) => o.Key)
-    .map((o) => deleteFile(o.Key!));
-  const results = await Promise.allSettled(deletions);
+  const keyedObjects = objects.filter((o) => o.Key);
+  const results = await Promise.allSettled(keyedObjects.map((o) => deleteFile(o.Key!)));
   results.forEach((result, i) => {
     if (result.status === "rejected") {
-      console.error(`Failed to delete R2 object ${objects[i].Key}:`, result.reason);
+      console.error(`Failed to delete R2 object ${keyedObjects[i].Key}:`, result.reason);
     }
   });
 

--- a/src/routes/api/posts/[slug]/+server.ts
+++ b/src/routes/api/posts/[slug]/+server.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "$lib/auth/middleware";
 import { db } from "$lib/db";
 import { posts, series } from "$lib/db/schemas";
 import { generateUniqueSlug } from "$lib/server/slug";
+import { deleteFile, listFiles } from "$lib/storage/blob";
 import { error, json } from "@sveltejs/kit";
 import { asc, eq, max } from "drizzle-orm";
 import type { RequestHandler } from "./$types";
@@ -149,6 +150,18 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
   if (!post) throw error(404, "Post not found");
 
   await db.delete(posts).where(eq(posts.id, post.id));
+
+  // Delete all R2 objects stored under posts/{slug}/
+  const objects = await listFiles(`posts/${post.slug}/`);
+  const deletions = objects
+    .filter((o) => o.Key)
+    .map((o) => deleteFile(o.Key!));
+  const results = await Promise.allSettled(deletions);
+  results.forEach((result, i) => {
+    if (result.status === "rejected") {
+      console.error(`Failed to delete R2 object ${objects[i].Key}:`, result.reason);
+    }
+  });
 
   return json({ success: true });
 };

--- a/src/routes/api/posts/[slug]/+server.ts
+++ b/src/routes/api/posts/[slug]/+server.ts
@@ -8,13 +8,16 @@ import { error, json } from "@sveltejs/kit";
 import { asc, eq, max } from "drizzle-orm";
 import type { RequestHandler } from "./$types";
 
-async function getPostBySlug(slug: string) {
-  const [post] = await db.select().from(posts).where(eq(posts.slug, slug)).limit(1);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function getPost(slugOrId: string) {
+  const col = UUID_RE.test(slugOrId) ? posts.id : posts.slug;
+  const [post] = await db.select().from(posts).where(eq(col, slugOrId)).limit(1);
   return post ?? null;
 }
 
 export const GET: RequestHandler = async ({ params, locals }) => {
-  const post = await getPostBySlug(params.slug);
+  const post = await getPost(params.slug);
   if (!post) throw error(404, "Post not found");
 
   const privileged = isPrivilegedUser(locals.user);
@@ -70,7 +73,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 export const PUT: RequestHandler = async ({ params, request, locals }) => {
   requireAdmin({ locals } as any);
 
-  const post = await getPostBySlug(params.slug);
+  const post = await getPost(params.slug);
   if (!post) throw error(404, "Post not found");
 
   const body = await request.json();
@@ -146,20 +149,24 @@ export const PUT: RequestHandler = async ({ params, request, locals }) => {
 export const DELETE: RequestHandler = async ({ params, locals }) => {
   requireAdmin({ locals } as any);
 
-  const post = await getPostBySlug(params.slug);
+  const post = await getPost(params.slug);
   if (!post) throw error(404, "Post not found");
 
   await db.delete(posts).where(eq(posts.id, post.id));
 
-  // Delete all R2 objects stored under posts/{id}/ (stable across slug renames)
-  const objects = await listFiles(`posts/${post.id}/`);
-  const keyedObjects = objects.filter((o) => o.Key);
-  const results = await Promise.allSettled(keyedObjects.map((o) => deleteFile(o.Key!)));
-  results.forEach((result, i) => {
-    if (result.status === "rejected") {
-      console.error(`Failed to delete R2 object ${keyedObjects[i].Key}:`, result.reason);
-    }
-  });
+  // R2 cleanup is best-effort — don't let storage errors fail the delete response
+  try {
+    const objects = await listFiles(`posts/${post.id}/`);
+    const keyedObjects = objects.filter((o) => o.Key);
+    const results = await Promise.allSettled(keyedObjects.map((o) => deleteFile(o.Key!)));
+    results.forEach((result, i) => {
+      if (result.status === "rejected") {
+        console.error(`Failed to delete R2 object ${keyedObjects[i].Key}:`, result.reason);
+      }
+    });
+  } catch (e) {
+    console.error(`Failed to clean up R2 objects for post ${post.id}:`, e);
+  }
 
   return json({ success: true });
 };

--- a/src/routes/api/posts/cover/+server.ts
+++ b/src/routes/api/posts/cover/+server.ts
@@ -14,9 +14,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
   validateFile(file, "image");
 
+  const slug = formData.get("slug");
+  const folder = slug ? `posts/${slug}` : "posts/_draft";
+
   const timestamp = Date.now();
   const safeName = sanitizeFilename(file.name);
-  const path = `posts/covers/${timestamp}-${safeName}`;
+  const path = `${folder}/${timestamp}-${safeName}`;
 
   const { url } = await uploadFile(file, "image", path);
 

--- a/src/routes/api/posts/cover/+server.ts
+++ b/src/routes/api/posts/cover/+server.ts
@@ -14,8 +14,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
   validateFile(file, "image");
 
-  const postId = formData.get("postId") as string | null;
-  if (!postId) throw error(400, "postId is required");
+  const postId = formData.get("postId");
+  if (typeof postId !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(postId)) {
+    throw error(400, "postId must be a valid UUID");
+  }
 
   const timestamp = Date.now();
   const safeName = sanitizeFilename(file.name);

--- a/src/routes/api/posts/cover/+server.ts
+++ b/src/routes/api/posts/cover/+server.ts
@@ -14,12 +14,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
   validateFile(file, "image");
 
-  const slug = formData.get("slug");
-  const folder = slug ? `posts/${slug}` : "posts/_draft";
+  const postId = formData.get("postId") as string | null;
+  if (!postId) throw error(400, "postId is required");
 
   const timestamp = Date.now();
   const safeName = sanitizeFilename(file.name);
-  const path = `${folder}/${timestamp}-${safeName}`;
+  const path = `posts/${postId}/${timestamp}-${safeName}`;
 
   const { url } = await uploadFile(file, "image", path);
 

--- a/src/routes/backpacking/[id]/+page.svelte
+++ b/src/routes/backpacking/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
-  import { replaceState } from "$app/navigation";
+  import { replaceState, goto } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
@@ -33,7 +33,6 @@
   import FileUpload from "$lib/components/FileUpload.svelte";
   import ImageLightbox from "$lib/components/ImageLightbox.svelte";
   import { Flag, X, Trash2, Shield } from "lucide-svelte";
-  import { goto } from "$app/navigation";
 
   export let data: PageData;
 

--- a/src/routes/backpacking/[id]/+page.svelte
+++ b/src/routes/backpacking/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
+  import { replaceState } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
@@ -81,7 +82,7 @@
   $: if (browser) {
     const newHash = `#${activeTab}`;
     if (window.location.hash !== newHash) {
-      history.replaceState(null, "", newHash);
+      replaceState(newHash, {});
     }
   }
 

--- a/src/routes/blog/[slug]/+page.server.ts
+++ b/src/routes/blog/[slug]/+page.server.ts
@@ -1,4 +1,5 @@
 import { marked } from "marked";
+import sanitizeHtml from "sanitize-html";
 import { error } from "@sveltejs/kit";
 import { workosAuth } from "$lib/server/workos";
 import type { PageServerLoad } from "./$types";
@@ -9,7 +10,14 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
   if (!res.ok) throw error(res.status, "Failed to load post");
 
   const { seriesData, ...post } = await res.json();
-  const rawContent = String(await marked(post.body));
+  const rawContent = sanitizeHtml(String(await marked(post.body)), {
+    allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img", "h1", "h2", "h3", "h4"]),
+    allowedAttributes: {
+      ...sanitizeHtml.defaults.allowedAttributes,
+      img: ["src", "alt", "title", "width", "height"],
+      "*": ["id", "class"],
+    },
+  });
 
   // Inject IDs into headings and build ToC
   const toc: { id: string; text: string; level: number }[] = [];

--- a/src/routes/blog/[slug]/+page.server.ts
+++ b/src/routes/blog/[slug]/+page.server.ts
@@ -10,18 +10,22 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
   if (!res.ok) throw error(res.status, "Failed to load post");
 
   const { seriesData, ...post } = await res.json();
-  const rawContent = sanitizeHtml(String(await marked(post.body)), {
+  const sanitizedContent = sanitizeHtml(String(await marked(post.body)), {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img", "h1", "h2", "h3", "h4"]),
     allowedAttributes: {
       ...sanitizeHtml.defaults.allowedAttributes,
       img: ["src", "alt", "title", "width", "height"],
-      "*": ["id", "class"],
+      "*": ["id"],
+      code: ["class"],
+    },
+    allowedClasses: {
+      code: ["language-*"],
     },
   });
 
   // Inject IDs into headings and build ToC
   const toc: { id: string; text: string; level: number }[] = [];
-  const content = rawContent.replace(/<h([2-4])>(.*?)<\/h\1>/gs, (_, lvl, inner) => {
+  const content = sanitizedContent.replace(/<h([2-4])>(.*?)<\/h\1>/gs, (_, lvl, inner) => {
     const plainText = inner.replace(/<[^>]+>/g, "");
     const id = plainText
       .toLowerCase()

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -106,4 +106,7 @@
   :global(.prose h2, .prose h3, .prose h4) {
     scroll-margin-top: 6rem;
   }
+  :global(.prose img) {
+    border-radius: 0.75rem;
+  }
 </style>

--- a/src/routes/camping/[id]/+page.svelte
+++ b/src/routes/camping/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
+  import { replaceState } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
@@ -86,7 +87,7 @@
   $: if (browser) {
     const newHash = `#${activeTab}`;
     if (window.location.hash !== newHash) {
-      history.replaceState(null, "", newHash);
+      replaceState(newHash, {});
     }
   }
 

--- a/src/routes/camping/[id]/+page.svelte
+++ b/src/routes/camping/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
-  import { replaceState } from "$app/navigation";
+  import { replaceState, goto } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
@@ -36,7 +36,6 @@
   import { SITE_TYPE_LABELS } from "$lib/db/schemas/enums";
   import FileUpload from "$lib/components/FileUpload.svelte";
   import ImageLightbox from "$lib/components/ImageLightbox.svelte";
-  import { goto } from "$app/navigation";
 
   export let data: PageData;
 

--- a/src/routes/hikes/[id]/+page.svelte
+++ b/src/routes/hikes/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
-  import { replaceState } from "$app/navigation";
+  import { replaceState, invalidateAll, goto } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
@@ -34,7 +34,6 @@
   import FileUpload from "$lib/components/FileUpload.svelte";
   import ImageLightbox from "$lib/components/ImageLightbox.svelte";
   import { Flag, X, Trash2, Shield } from "lucide-svelte";
-  import { invalidateAll, goto } from "$app/navigation";
 
   export let data: PageData;
 

--- a/src/routes/hikes/[id]/+page.svelte
+++ b/src/routes/hikes/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
+  import { replaceState } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
@@ -81,7 +82,7 @@
   $: if (browser) {
     const newHash = `#${activeTab}`;
     if (window.location.hash !== newHash) {
-      history.replaceState(null, "", newHash);
+      replaceState(newHash, {});
     }
   }
 


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on enhanced blog editing features, improved HTML sanitization for blog content, better cache control for HTML pages, and minor dependency and navigation updates. The most significant changes are grouped and summarized below.

**Blog Editor Enhancements:**

* Added inline image upload support to both the new and edit blog post pages. Users can now insert images directly into the Markdown editor, with visual feedback during upload and automatic Markdown insertion upon success. (`src/routes/admin/blog/[slug]/edit/+page.svelte` [src/routes/admin/blog/[slug]/edit/+page.svelteR17](diffhunk://#diff-6b72065a6720e94768a303193e2a871c71879555ac95c15ff7545cff93a5f9e4R17), [src/routes/admin/blog/[slug]/edit/+page.svelteR94-R118](diffhunk://#diff-6b72065a6720e94768a303193e2a871c71879555ac95c15ff7545cff93a5f9e4R94-R118), [src/routes/admin/blog/[slug]/edit/+page.svelteL332-R366](diffhunk://#diff-6b72065a6720e94768a303193e2a871c71879555ac95c15ff7545cff93a5f9e4L332-R366); `src/routes/admin/blog/new/+page.svelte` [[1]](diffhunk://#diff-06c185c6f64eaaa0f1e2f130350c399d715e602d65956a1836a3ee79b5a2b413R16) [[2]](diffhunk://#diff-06c185c6f64eaaa0f1e2f130350c399d715e602d65956a1836a3ee79b5a2b413R74-R98) [[3]](diffhunk://#diff-06c185c6f64eaaa0f1e2f130350c399d715e602d65956a1836a3ee79b5a2b413L301-R335)

**Security and Content Handling:**

* Implemented HTML sanitization for rendered blog post content using `sanitize-html`, allowing only safe tags and attributes, including support for images and heading tags. This mitigates XSS risks in blog content. (`src/routes/blog/[slug]/+page.server.ts` [src/routes/blog/[slug]/+page.server.tsR2](diffhunk://#diff-66cf0cbe687f1fde77cfac27f8115885fbd18d06585e88501a9b5b2c8924a6d4R2), [src/routes/blog/[slug]/+page.server.tsL12-R20](diffhunk://#diff-66cf0cbe687f1fde77cfac27f8115885fbd18d06585e88501a9b5b2c8924a6d4L12-R20))
* Added a style to round the corners of images in blog content for a more polished look. (`src/routes/blog/[slug]/+page.svelte` [src/routes/blog/[slug]/+page.svelteR109-R111](diffhunk://#diff-b7310ac16ea84c71f28fa6506e4805b0ab2d64fedc19642dbb1497e816ecc269R109-R111))

**Performance and Caching:**

* Ensured all HTML responses are served with `Cache-Control: no-store` to prevent caching issues due to Cloudflare Pages not retaining old assets after deploys. (`src/hooks.server.ts` [src/hooks.server.tsR182-R186](diffhunk://#diff-b5aa13ce0a61c3f166000471d0729aa6a8e57292fdbd8d88452443502e4b9a4aR182-R186))

**Navigation Improvements:**

* Replaced direct `history.replaceState` calls with SvelteKit's `replaceState` utility for hash-based tab navigation in trip detail pages, aligning with framework best practices. (`src/routes/backpacking/[id]/+page.svelte` [src/routes/backpacking/[id]/+page.svelteR3](diffhunk://#diff-08a482e8dfd5be362ff1700476a486d88efb47146011700441452696e7617225R3), [src/routes/backpacking/[id]/+page.svelteL84-R85](diffhunk://#diff-08a482e8dfd5be362ff1700476a486d88efb47146011700441452696e7617225L84-R85); `src/routes/camping/[id]/+page.svelte` [src/routes/camping/[id]/+page.svelteR3](diffhunk://#diff-3bcad7b3feb0c63d0625661fc4222991ecf980940357be5ea911c4a451432584R3), [src/routes/camping/[id]/+page.svelteL89-R90](diffhunk://#diff-3bcad7b3feb0c63d0625661fc4222991ecf980940357be5ea911c4a451432584L89-R90); `src/routes/hikes/[id]/+page.svelte` [src/routes/hikes/[id]/+page.svelteR3](diffhunk://#diff-84a97cf6ec38d7b6d28d34aa6417057cda4acbbc7a6d3e0e4b43dc2ec73f7540R3), [src/routes/hikes/[id]/+page.svelteL84-R85](diffhunk://#diff-84a97cf6ec38d7b6d28d34aa6417057cda4acbbc7a6d3e0e4b43dc2ec73f7540L84-R85))

**Dependency Updates:**

* Added `sanitize-html` and its type definitions to `package.json` for HTML sanitization. (`package.json` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R47) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L88-R90)

**Workflow Adjustment:**

* Modified the deploy preview workflow to run without requiring tests to pass, only depending on migrations. (`.github/workflows/deploy-preview.yml` [.github/workflows/deploy-preview.ymlL89-R89](diffhunk://#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0L89-R89))