### PR TITLE
Preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ secrets.json
 e2e/.auth/
 playwright-report/
 test-results/
+.fallow/churn.bin
+.fallow/cache.bin

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -73,7 +73,7 @@
     { href: "/hikes", label: "Hikes", icon: MountainIcon, activeColor: "emerald" },
     { href: "/camping", label: "Camping Sites", icon: Tent, activeColor: "blue" },
     { href: "/backpacking", label: "Backpacking", icon: Backpack, activeColor: "amber" },
-    // { href: "/blog", label: "Blog", icon: BookOpen, activeColor: "indigo" },
+    { href: "/blog", label: "Blog", icon: BookOpen, activeColor: "indigo" },
   ];
 
   const activeColors: Record<


### PR DESCRIPTION
This pull request makes a small update to the navigation menu in the `Header.svelte` component by enabling the "Blog" link, which was previously commented out.

* Re-enabled the "Blog" navigation item in the `Header.svelte` component so that it now appears in the site's main navigation.