### PR TITLE
U7: attach production custom domains

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,10 @@
     "binding": "ASSETS",
     "run_worker_first": ["/api/*"],
   },
+  "routes": [
+    { "pattern": "adventurespark.org", "custom_domain": true },
+    { "pattern": "www.adventurespark.org", "custom_domain": true },
+  ],
   "ratelimits": [
     {
       "name": "RATE_LIMITER_IMAGE",


### PR DESCRIPTION
Both adventurespark.org and www.adventurespark.org have been detached
from the Pages project. This adds both as Worker custom domain routes
in wrangler.jsonc's top-level config so the production Worker claims
them. Merging promptly since the domains are currently unclaimed by
either service until this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)