### PR TITLE
feat: add trip completion log with lifetime miles/nights totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,43 @@ npm run db:migrate
 ```bash
 npm run dev
 ```
+
+## Deployment
+
+The app deploys to Cloudflare Workers. Deploys are triggered by pushing to two branches:
+
+- **`preview`** → runs unit tests, runs DB migrations, deploys to `https://preview.adventurespark.org`, then runs e2e tests against it (`.github/workflows/deploy-preview.yml`)
+- **`main`** → runs DB migrations, deploys to `https://adventurespark.org`, then deploys the scheduler Worker (`.github/workflows/deploy-prod.yml`)
+
+Migrations run as their own CI job and gate the deploy job — a failed migration blocks the deploy. To ship a change:
+
+```bash
+git checkout preview
+git merge feat/your-branch
+git push                    # deploys to preview automatically
+
+# once verified on preview:
+git checkout main
+git merge preview
+git push                    # deploys to production automatically
+```
+
+### Manual deploy (fallback)
+
+Only needed if CI is unavailable — requires `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` set locally and `npm run db:migrate` run against the target database first:
+
+```bash
+npm run deploy:preview      # npm run build && wrangler deploy --env preview
+npm run deploy:prod         # npm run build && wrangler deploy
+```
+
+### Secrets
+
+App secrets (WorkOS, R2, `CRON_SECRET`, etc.) are uploaded to the Worker separately from `.env`:
+
+```bash
+npm run secrets:upload:preview   # reads .env
+npm run secrets:upload:prod      # reads .env.prod
+```
+
+The `adventures-scheduler` Worker (`workers/scheduler/`) has its own secrets (`APP_URL`, `CRON_SECRET`) set once per environment via `wrangler secret put` — see `CLAUDE.md` for the exact commands.

--- a/docs/plans/2026-07-09-001-feat-trip-completion-log-plan.md
+++ b/docs/plans/2026-07-09-001-feat-trip-completion-log-plan.md
@@ -1,0 +1,383 @@
+---
+title: Trip Completion Log - Plan
+type: feat
+date: 2026-07-09
+topic: trip-completion-log
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Trip Completion Log - Plan
+
+## Goal Capsule
+
+- **Objective:** Implement self-reported trip completion logging for hikes, camping sites, and backpacking trips, with per-user lifetime totals (miles hiked, nights camped, trip count), per the Product Contract below.
+- **Authority hierarchy:** Product Contract is authoritative for product scope. Planning Contract and Implementation Units are authoritative for technical approach. Do not invent product behavior beyond what's specified here.
+- **Execution profile:** Standard-depth feature, six implementation units. U1 (schema) is foundational; U2 and U4 depend on U1; U3 depends on U1 and U2 (adds a `GET` handler to the same `+server.ts` file U2 creates); U5 depends on U2 and U3; U6 depends on U3 and U4.
+- **Stop conditions:** All units complete, Verification Contract gates pass, Definition of Done criteria met.
+- **Tail ownership:** Standard repo conventions — `npm run db:migrate` for schema changes, PR review via the repo's existing CI (`deploy-preview.yml` / `deploy-prod.yml`).
+- **Open blockers:** none.
+
+## Product Contract
+
+**Product Contract preservation:** changed — R9 added (delete own log entries), and the Scope Boundaries "Deferred for later" list updated to match. Confirmed with the user during planning (flow analysis flagged the no-correction-mechanism gap as highest severity given there's no leader-approval workflow). All other Product Contract content unchanged from the brainstorm.
+
+### Summary
+
+Add a self-reported "Log as completed" action to hike, camping-site, and backpacking-trip listings. Each log entry captures the trip's stats — auto-filled from the listing where available, manually entered for camping nights-stayed — and rolls up into a private-by-default lifetime totals view, shareable via an opt-in toggle. Users can delete their own mistaken log entries.
+
+### Problem Frame
+
+Scouts and leaders currently duplicate distance/night bookkeeping by hand: this platform already stores trail distance, elevation, and duration for its own listings, but nothing on the platform — and nothing in BSA's own Scoutbook, which requires manual mileage entry — uses that data to save a scout from re-typing it into a personal record. Ideation on scouting-specific differentiation surfaced this as the platform's strongest independent bet: unlike unit/roster or leader-approval features, it needs no organizational data and delivers value from a single user's own logged trips alone.
+
+### Key Decisions
+
+- **Self-report, no verification.** Any signed-in user marks their own trips complete; no leader or parent approval gates a log entry. This is personal progress tracking, not the official merit-badge sign-off record, which still happens with a real counselor outside the app.
+- **Raw totals only — no badge-name claims.** The dashboard shows lifetime miles hiked, nights camped, and trip counts. It never asserts a specific merit badge is "earned" or tracks program-specific thresholds, avoiding both admin-configurable requirement tables and an inaccurate official claim.
+- **Private by default, shareable via toggle.** Mirrors the existing `showUnitInfo` privacy pattern on user profiles — a user's log and totals are visible only to them unless they opt in to sharing.
+- **Multiple completions per entity are allowed.** Unlike `favorites` (unique per user per entity), a user can log the same hike or campsite complete more than once — each visit is its own entry.
+- **Camping requires manual "nights stayed" entry.** Camping-site records only store site-level cost/season data, not per-visit duration, so nights-stayed is filled in by the user at logging time rather than supplied by the listing.
+- **Users can delete their own log entries.** Added during planning: with no leader-approval step to catch mistakes, a basic self-service correction path is necessary. Deleting recomputes the user's totals.
+
+### Actors
+
+- A1. Any signed-in platform user (scout, parent, or leader) acting on their own account. No distinct roles are needed since there is no approval workflow.
+
+### Requirements
+
+**Logging a trip**
+
+- R1. A signed-in user can mark a hike, camping site, or backpacking trip as completed from that listing's detail page.
+- R2. For hikes and backpacking trips, the log entry auto-fills distance, duration, and elevation from the listing's existing data when present.
+- R3. For camping sites, the user manually enters nights stayed when logging a completion; other stats are not auto-filled since camping sites don't track per-visit duration.
+- R4. A user may log the same listing as completed more than once, each as an independent entry.
+- R5. If a hike or backpacking trip's distance, duration, or elevation is unset on the listing, the user can still log a completion; the missing figures simply don't contribute to that entry's totals.
+
+**Totals and display**
+
+- R6. The platform maintains a running lifetime total per user of miles hiked, nights camped, and total trips completed, derived from that user's log entries.
+- R7. Totals are visible only to the logging user by default.
+- R8. A user can opt in to sharing their totals (e.g., visible on their profile), mirroring the existing unit-info visibility toggle pattern.
+
+**Correcting a log**
+
+- R9. A user can delete one of their own completion log entries; the deletion recomputes their lifetime totals to no longer include it.
+
+### Acceptance Examples
+
+- AE1. **Covers R2, R3.** Given a hike listing with `distance` set, When a user logs a completion, Then the entry auto-fills that distance. Given a camping-site listing, When a user logs a completion, Then they are prompted to enter nights stayed manually.
+- AE2. **Covers R4.** Given a user has already logged a trail as completed once, When they log the same trail as completed again, Then a second independent entry is created and both count toward totals.
+- AE3. **Covers R5.** Given a hike listing with `distance` left blank, When a user logs a completion, Then the entry saves successfully and contributes 0 to the mileage total rather than erroring.
+- AE4. **Covers R7, R8.** Given a user has never changed their sharing setting, When another user views their profile, Then no completion totals are shown. When the user opts in to sharing, Then totals become visible on their profile.
+- AE5. **Covers R9.** Given a user has logged a hike complete once, When they delete that log entry, Then it no longer appears in their history and their lifetime totals decrease by that entry's contributed miles.
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- Badge-threshold matching and admin-configurable merit-badge requirement tables — v1 shows raw totals, not badge-specific progress.
+- Leader or parent approval workflow for logged completions.
+- Freeform logging for trips to places not in the platform's catalog.
+- Editing a past log entry's values (deletion is now in scope per R9, but correcting a wrong nights-stayed value in place is not — a user redoes it by deleting and re-logging).
+- A public-facing surface for shared totals. No public profile page exists yet; this plan wires the sharing toggle and self-view only (see KTD5).
+
+**Outside this product's identity**
+
+- Any tie-in to unit/roster/leader-certification data — a separate, larger idea already deferred pending a build-vs-integrate decision against the user's sibling Unit Spark project.
+
+### Dependencies / Assumptions
+
+- Assumes the existing `distance`/`duration`/`elevation` fields on hike and backpacking listings are reliable enough to auto-fill from; accuracy of individual listings is out of scope here.
+- Assumes camping sites will not gain a per-visit duration field as part of this work — nights-stayed stays a log-entry-level input, not a site-level one.
+
+### Sources / Research
+
+- `docs/ideation/2026-07-08-scouting-differentiation-features-ideation.html` — originating ideation entry, including the decision to defer roster/badge-threshold work pending the Unit Spark integration question.
+- `src/lib/db/schemas/favorites.ts` — three-nullable-FK per-user-per-entity pattern; the completion log reuses this shape but drops the unique index (repeats are allowed).
+- `src/lib/db/schemas/ratings.ts` — same three-FK shape plus a CHECK constraint enforcing exactly one FK is non-null; reused for the completion log table.
+- `src/lib/db/schemas/rating-aggregates.ts` and `src/routes/api/ratings/+server.ts`'s `updateRatingAggregates()` — the denormalized-cache pattern (atomic `INSERT...SELECT...ON CONFLICT DO UPDATE`) the per-user stats aggregate follows, adapted from per-entity to per-user keying.
+- `src/lib/db/schemas/hikes.ts`, `src/lib/db/schemas/backpacking.ts`, `src/lib/db/schemas/camping-sites.ts` — confirmed field names/types for `distance`/`duration`/`elevation`/`numberOfNights`, and confirmed camping sites have no per-visit duration field.
+- `src/lib/db/schemas/user-profiles.ts` and `src/routes/profile/+page.server.ts` — the `showUnitInfo` toggle and its `onConflictDoUpdate` persistence pattern, mirrored for the new sharing toggle.
+- `src/lib/components/` `FavoriteButton.svelte` — client-side pattern (optimistic update, auth-redirect-on-click, `onMount` state fetch) the new logging button follows structurally, adapted from a toggle to a repeatable action.
+- `src/lib/allowed-fields.ts` — confirms `distance`/`duration`/`elevation` are user-alterable fields on live listings via the existing alteration-proposal workflow, which is why completion-log values must be snapshotted rather than re-derived live (see KTD1).
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1 — Snapshot values at log time, never live-recompute.** `distance`/`duration`/`elevation` are user-alterable via the existing alteration-proposal workflow, so a listing's values can change after a user has already logged against it. The completion log row stores its own copy of the value and unit at write time; the per-user aggregate sums from the log rows themselves, never re-joins to the live entity. This keeps a user's lifetime totals stable and auditable — an admin or alteration approval editing a trail later does not silently rewrite anyone's history.
+- **KTD2 — Reuse the three-nullable-FK shape, minus uniqueness.** The completion log table mirrors `favorites`/`ratings`: `hikeId`/`campingSiteId`/`backpackingId` nullable FK columns with `onDelete: "cascade"`, plus a CHECK constraint (from `ratings.ts`) enforcing exactly one is non-null. Unlike both existing tables, no unique index — R4 requires repeat logging. Kept over the discriminator-enum shape used by `moderation_queue.ts` (`entityType` + single `entityId`) because per-type FKs give referential integrity and per-entity-type cascade-delete semantics at the database level, which a single polymorphic `entityId` column can't express in Postgres.
+- **KTD3 — Per-user aggregate recomputed via atomic upsert.** The `completion_stats` table (one row per user) is recomputed after every insert or delete using a single `INSERT ... SELECT ... ON CONFLICT DO UPDATE` against the user's own `trip_completions` rows, mirroring `updateRatingAggregates()`'s single-statement form — the same pattern chosen there specifically to avoid a race window a two-query read-then-write approach had. The recompute query must `COALESCE` each summed column to `0` (`SUM()` over an all-NULL group — e.g. a camping-only user, whose rows never set `distance` — returns `NULL` in Postgres, not `0`, which would otherwise contradict AE3 and the columns' "defaulting to 0" intent) and must convert kilometers-denominated rows before summing (e.g. `SUM(COALESCE(CASE WHEN distance_unit = 'kilometers' THEN distance * 0.621371 ELSE distance END, 0))`), since `distanceUnit` is a real per-listing choice (`distanceUnitEnum` = `["miles", "kilometers"]`) and KTD1 preserves each row's original unit rather than normalizing at write time.
+- **KTD4 — Cascade delete on entity removal is accepted behavior.** If an admin deletes a hike/camping-site/backpacking listing, any completion log rows referencing it cascade-delete (matching `favorites`/`ratings`), and the user's aggregate shrinks accordingly on next recompute. This is a known, documented consequence of KTD2's FK shape, not a defect.
+- **KTD5 — Sharing toggle lives on `user_profiles`, defaults to `false`.** Add `shareCompletionStats: boolean("share_completion_stats").default(false).notNull()` alongside `showUnitInfo`, using the same table and save-action pattern. Default is the inverse of `showUnitInfo`'s `true` default, since R7 requires private-by-default. No public profile page exists yet, so this plan persists and round-trips the flag but does not yet render shared totals to other viewers (see Scope Boundaries) — a future plan adds that surface.
+- **KTD6 — Elevation is captured but not surfaced in v1 totals.** R6 names miles hiked, nights camped, and trip count only. Elevation is still snapshotted per-entry (cheap, and useful if a future view wants it) but the `completion_stats` aggregate and the profile UI do not sum or display it in this plan.
+- **KTD7 — Nights-stayed validation: integer, 1–90.** Rejects 0, negative, and non-integer input. Chosen as a generous but sane bound for a single camping stay; adjustable later without a schema change.
+- **KTD8 — Delete targets the log row's own ID, not entity-matched query params.** Because repeat logging is allowed, deleting "the completion for hike X" is ambiguous when more than one exists. `DELETE /api/completions/[id]` operates on the specific log row's primary key, scoped to `userId = session user`.
+
+### High-Level Technical Design
+
+Data flow for logging and correcting a completion:
+
+```mermaid
+flowchart TB
+    A[User clicks Log Complete on a listing] --> B{Entity type?}
+    B -->|Hike / Backpacking| C[Snapshot distance/duration/elevation from listing]
+    B -->|Camping site| D[Collect nights-stayed input, 1-90]
+    C --> E[INSERT into trip_completions]
+    D --> E
+    E --> F[Recompute completion_stats for userId\nINSERT...SELECT...ON CONFLICT DO UPDATE]
+    F --> G[Return updated totals to client]
+
+    H[User deletes a past entry] --> I[DELETE trip_completions row\nscoped to owner]
+    I --> F
+```
+
+Entity relationship shape (mirrors `ratings`/`favorites`, minus uniqueness, plus per-user aggregate):
+
+```mermaid
+erDiagram
+    HIKES ||--o{ TRIP_COMPLETIONS : "hikeId (nullable)"
+    CAMPING_SITES ||--o{ TRIP_COMPLETIONS : "campingSiteId (nullable)"
+    BACKPACKING ||--o{ TRIP_COMPLETIONS : "backpackingId (nullable)"
+    USER_PROFILES ||--o| COMPLETION_STATS : "userId (unique)"
+    TRIP_COMPLETIONS }o--|| COMPLETION_STATS : "summed per userId"
+```
+
+### Assumptions
+
+- The session/auth layer (`requireAuth()`) reliably exposes a stable `userId` usable as the FK target for both `trip_completions.userId` and `completion_stats.userId`, consistent with existing `favorites`/`ratings`/`user_profiles` usage.
+- `db:migrate` (drizzle-kit push) is sufficient for adding two new tables and one new column; no data backfill is needed since this is new functionality with no prior rows.
+
+---
+
+## Implementation Units
+
+### U1. Schema: completion log and per-user stats aggregate
+
+**Goal:** Establish the data model for logging completions and tracking per-user lifetime totals.
+
+**Requirements:** R1–R6, R9
+
+**Dependencies:** none
+
+**Files:**
+
+- `src/lib/db/schemas/completions.ts` (new)
+- `src/lib/db/schemas/completion-stats.ts` (new)
+- `src/lib/db/schemas/user-profiles.ts` (modify — add `shareCompletionStats` column)
+- `src/lib/db/schemas/index.ts` (modify — register new schema exports)
+
+**Approach:** `completions.ts` defines `tripCompletions`: `id` (uuid pk), `userId` (text), three nullable FKs (`hikeId`/`campingSiteId`/`backpackingId`, each `onDelete: "cascade"`), a CHECK constraint requiring exactly one FK non-null (KTD2), a second CHECK constraint on `nights` (`nights IS NULL OR (nights >= 1 AND nights <= 90)`, mirroring `ratings.ts`'s `ratingValueCheck` per KTD7), snapshot columns (`distance`, `distanceUnit`, `duration`, `durationUnit`, `elevation`, `elevationUnit`, `nights`), `createdAt`. Plain (non-unique) indexes on `userId` and each FK column — no unique index. `completion-stats.ts` defines `completionStats`: `userId` (text, primary key), `totalMiles` (numeric), `totalNights` (integer), `tripCount` (integer), each defaulting to 0. Add `shareCompletionStats` boolean (default `false`) to `user-profiles.ts` per KTD5. Register both new files in `index.ts` following the existing `export * from "./..."` convention.
+
+**Patterns to follow:** `src/lib/db/schemas/ratings.ts` (CHECK constraint shape, three-FK columns), `src/lib/db/schemas/favorites.ts` (FK/index shape, minus uniqueness), `src/lib/db/schemas/rating-aggregates.ts` (aggregate table shape, adapted to per-user).
+
+**Test scenarios:**
+
+- Migration applies cleanly via `npm run db:migrate`.
+- Inserting a `trip_completions` row with zero FKs set is rejected by the CHECK constraint.
+- Inserting a row with two FKs set is rejected by the CHECK constraint.
+- Inserting a row with `nights` set to 0, negative, or above 90 is rejected by the CHECK constraint.
+- Inserting two rows with the same `(userId, hikeId)` pair both succeed (no unique constraint blocks it).
+- Deleting a referenced hike/camping-site/backpacking row cascades to delete its `trip_completions` rows.
+
+**Verification:** `db.query.tripCompletions` and `db.query.completionStats` are queryable after migration; TypeScript types (`TripCompletion`, `NewTripCompletion`, `CompletionStats`) export correctly from their schema files.
+
+---
+
+### U2. API: create a completion log entry
+
+**Goal:** Let a signed-in user log a trip as completed, with server-side auto-fill/snapshot and stats recompute.
+
+**Requirements:** R1, R2, R3, R4, R5, R6. Covers AE1, AE2, AE3.
+
+**Dependencies:** U1
+
+**Files:**
+
+- `src/routes/api/completions/+server.ts` (new — `POST` handler; also see U3 for `GET` on the same file)
+
+**Approach:** Guard with `requireAuth()`. Accept `hikeId` / `campingSiteId` / `backpackingId` (exactly one) plus, for camping, a required `nights` field. For hikes/backpacking, look up the live listing's `distance`/`distanceUnit`/`duration`/`durationUnit`/`elevation`/`elevationUnit` and copy them onto the new row (null values snapshot as null/0 per AE3 — KTD1). For camping, validate `nights` as an integer in 1–90 (KTD7) and store it; other snapshot columns stay null. Plain `db.insert(tripCompletions).values(...)` — no `onConflictDoNothing`/`onConflictDoUpdate`, since repeats are allowed (simpler than the `favorites`/`ratings` POST handlers). After insert, recompute the user's `completion_stats` row via a single `INSERT ... SELECT ... ON CONFLICT DO UPDATE` summing `distance` (normalized to miles) and `nights` across that user's `trip_completions` rows (KTD3).
+
+**Technical design:**
+
+```
+POST /api/completions
+body: { hikeId? | campingSiteId? | backpackingId?, nights? }
+  -> validate exactly one entity id present (400 otherwise)
+  -> if campingSiteId: require integer nights in [1,90] (400 otherwise)
+  -> if hikeId | backpackingId: snapshot distance/duration/elevation (+units) from live listing
+  -> insert trip_completions row
+  -> recompute completion_stats for userId (INSERT...SELECT...ON CONFLICT DO UPDATE,
+     COALESCE each summed column to 0, convert kilometers rows to miles before summing — KTD3)
+  -> 201 with the created row
+```
+
+**Patterns to follow:** `src/routes/api/ratings/+server.ts` for the `requireAuth()` guard, entity-count validation (`entityCount = [hikeId, campingSiteId, backpackingId].filter(Boolean).length`), and the `updateRatingAggregates()` atomic-upsert shape (adapt from per-entity to per-user keying).
+
+**Test scenarios:**
+
+- Happy path: logging a hike with `distance` set auto-fills that distance onto the new row and the user's `completion_stats.totalMiles` increases accordingly.
+- Happy path: logging a camping site with `nights: 3` creates a row with `nights: 3` and no distance/duration/elevation; `completion_stats.totalNights` increases by 3.
+- Edge case: logging a hike with `distance` null succeeds and contributes 0 to `totalMiles` (covers AE3).
+- Edge case: a user whose only logged completion is a camping site has `completion_stats.totalMiles = 0`, not `NULL` (KTD3 COALESCE).
+- Edge case: logging a hike with `distanceUnit: "kilometers"` contributes the correct miles-converted value to `totalMiles` (KTD3).
+- Edge case: logging the same hike twice creates two independent rows; `completion_stats` reflects the sum of both (covers AE2's downstream effect on totals).
+- Error path: request with zero of `hikeId`/`campingSiteId`/`backpackingId` set returns 400.
+- Error path: request with more than one of the three set returns 400.
+- Error path: camping request with missing, zero, negative, or non-integer `nights` returns 400.
+- Error path: unauthenticated request returns 401.
+- Integration: after a successful POST, a subsequent `GET /api/completions/my-stats` (U4) reflects the new totals.
+
+**Verification:** Manually POST against a seeded hike/camping-site/backpacking record in a dev environment and confirm the response row and updated stats match expectations for each entity type.
+
+---
+
+### U3. API: list and delete completion log entries
+
+**Goal:** Let a user view their own logged history and delete a mistaken entry.
+
+**Requirements:** R6 (supports totals display), R9. Covers AE5.
+
+**Dependencies:** U1, U2 (adds a `GET` handler to the `+server.ts` file U2 creates)
+
+**Files:**
+
+- `src/routes/api/completions/+server.ts` (modify — add `GET` handler alongside U2's `POST`)
+- `src/routes/api/completions/[id]/+server.ts` (new — `DELETE` handler)
+
+**Approach:** `GET /api/completions` is always scoped to `userId = session user` (no viewing another user's raw entries, regardless of their sharing toggle — sharing only exposes the aggregate, not the entry list, per Scope Boundaries). Accepts optional `hikeId`/`campingSiteId`/`backpackingId` query params to filter to a single entity (used by the detail-page button in U5 to show "logged N times"); with no filter, returns all of the caller's entries (used by the profile history view in U6), ordered by `createdAt` descending, paginated via `parseLimit()`/`parseOffset()` from `$lib/utils/pagination.ts` matching the repo's other list endpoints (e.g. `GET /api/ratings`). Each returned row joins to its hike/camping-site/backpacking record (via whichever FK is non-null) to include the entity's name and slug, so the history view in U6 can identify which trip each entry belongs to. `DELETE /api/completions/[id]` loads the row by its primary key, verifies `row.userId === session user` (403 if not, 404 if the row doesn't exist), deletes it, recomputes `completion_stats` for that user the same way U2 does after insert (KTD3, KTD8), and returns the updated totals in its response body so U6 can apply them directly without a second request.
+
+**Patterns to follow:** `src/routes/api/favorites/[id]/+server.ts` for the auth-guarded single-row handler shape; note this unit's `DELETE` targets the log row's own ID directly rather than entity-matched query params, unlike favorites (KTD8).
+
+**Test scenarios:**
+
+- `GET /api/completions` returns only the caller's own entries, never another user's.
+- `GET /api/completions?hikeId=<id>` filters to entries for that hike only.
+- `GET /api/completions` returns each row with its entity's name/slug joined in.
+- `GET /api/completions` respects `limit`/`offset` query params and returns entries ordered newest-first.
+- `DELETE /api/completions/[id]` on the caller's own entry removes it, `completion_stats` decreases by that entry's contribution (covers AE5), and the response body includes the updated totals.
+- `DELETE /api/completions/[id]` on another user's entry returns 403.
+- `DELETE /api/completions/[id]` on a nonexistent ID returns 404.
+- Unauthenticated `GET` or `DELETE` returns 401.
+
+**Verification:** Log two entries for the same hike, delete one via the API, and confirm the remaining entry and updated stats are correct.
+
+---
+
+### U4. API: expose stats and persist the sharing toggle
+
+**Goal:** Let a user read their own lifetime totals and set their sharing preference.
+
+**Requirements:** R7, R8
+
+**Dependencies:** U1
+
+**Files:**
+
+- `src/routes/api/completions/my-stats/+server.ts` (new — `GET` handler)
+- `src/routes/profile/+page.server.ts` (modify — extend the existing profile save action to persist `shareCompletionStats`)
+
+**Approach:** `my-stats` returns the caller's `completion_stats` row, defaulting to zeros (`totalMiles: 0, totalNights: 0, tripCount: 0`) when no row exists yet (a user with no logged completions). No-store cache header, matching `ratings`'s per-user endpoints (response reflects live, user-scoped state). Extend the existing `?/saveProfile` form action (or add a sibling action) to accept and persist `shareCompletionStats` via the same `onConflictDoUpdate` pattern already used for `showUnitInfo`.
+
+**Patterns to follow:** `src/routes/api/ratings/my-rating/+server.ts`-equivalent single-resource `GET` shape; `src/routes/profile/+page.server.ts`'s existing save-action `onConflictDoUpdate` for `user_profiles`.
+
+**Test scenarios:**
+
+- `GET /api/completions/my-stats` for a user with no completions returns all zeros.
+- `GET /api/completions/my-stats` reflects correct sums after one or more completions are logged (integration with U2/U3's recompute step).
+- Saving the profile form with the sharing toggle enabled persists `shareCompletionStats: true` and round-trips on reload.
+- Unauthenticated `GET /api/completions/my-stats` returns 401.
+
+**Verification:** Toggle sharing on and off via the profile form and confirm the persisted value survives a page reload.
+
+---
+
+### U5. UI: Log-completion button and camping nights form
+
+**Goal:** Let a user log a completion from a hike, camping-site, or backpacking-trip detail page.
+
+**Requirements:** R1, R2, R3, R4. Covers AE1, AE2.
+
+**Dependencies:** U2, U3 (the button's `onMount` state fetch relies on U3's `GET /api/completions` handler)
+
+**Files:**
+
+- `src/lib/components/LogCompletionButton.svelte` (new)
+- Detail page components under `src/lib/components/detail-pages/` or the relevant hike/camping/backpacking detail route (modify — render the new button alongside the existing favorite/rating UI)
+
+**Approach:** Structurally mirror `FavoriteButton.svelte` (props for `hikeId`/`campingSiteId`/`backpackingId`/`userId`; `onMount` fetch of the current logged count via `GET /api/completions?<entityId>`; redirect to `/login` on click when unauthenticated), but this is **not a toggle** — every click creates a new entry. The log button (and the camping form's submit button) is disabled from click until its request resolves, guarding against an accidental double-click creating a duplicate entry — distinct from the intentional repeat-click behavior below, which is allowed once each prior request has completed. For hikes and backpacking, a click posts immediately (no user input required) with an optimistic count increment, rolled back — with a brief inline error ("Couldn't log this trip — try again") — on request failure. For camping sites, a click expands a small inline form collecting `nights` (client-side validated 1–90 before submit, matching KTD7) instead of posting immediately; on successful submission the form collapses/resets and the visible count increments the same way the hike/backpacking path does, and on failure it shows the same inline error without collapsing so the user can retry.
+
+**Test scenarios:**
+
+- Clicking the button on a hike/backpacking detail page creates a completion and the visible "logged N times" count increments.
+- Clicking the button on a camping-site detail page opens the nights-stayed form; submitting a valid value (1–90) creates the entry; submitting 0, a negative number, or a non-integer is rejected client-side without a request.
+- Repeated clicks on the same listing each create a new entry once each prior request has resolved (verifies non-toggle behavior, covers AE2 from the client side).
+- The button is disabled while a request is in flight, so a rapid double-click only creates one entry.
+- A failed POST (simulated network error) rolls the optimistic count back and shows an inline error.
+- Submitting the camping nights form successfully collapses the form and increments the visible count.
+
+**Verification:** Manually exercise the button on one listing of each entity type in a dev environment; confirm counts update correctly and the camping form validates before submission.
+
+---
+
+### U6. UI: Profile "My Adventures" stats and history
+
+**Goal:** Let a user see their lifetime totals, browse their logged history, delete entries, and control sharing.
+
+**Requirements:** R6, R7, R8, R9. Covers AE4, AE5.
+
+**Dependencies:** U3, U4
+
+**Files:**
+
+- `src/routes/profile/+page.svelte` (modify — add a new tab)
+- `src/routes/profile/+page.server.ts` (modify — load stats and history for the new tab; already extended in U4 for the save action)
+
+**Approach:** Add a new entry to the existing `tabs` array (alongside `profile`/`security`/`notes`). The new tab renders: lifetime totals from `GET /api/completions/my-stats` (U4); a list of the user's past entries from `GET /api/completions` (U3), each labeled with the entity's name (from U3's join) and a delete button wired to `DELETE /api/completions/[id]` (U3); the sharing toggle using the same toggle-switch markup as `showUnitInfo`, submitted through the profile save action (U4). The delete button requires a confirmation step (stating what will be removed and that totals will decrease) before the `DELETE` request fires. On a confirmed delete, the entry is removed from the visible history and the totals shown update directly from the `DELETE` response body (U3) — no separate re-fetch.
+
+**Patterns to follow:** The existing "Scout Unit" card block in `+page.server.ts`/`+page.svelte` (bordered card, `peer`/`peer-checked` toggle-switch markup, `use:enhance` form submission) as the template for both the sharing-toggle UI and the overall tab layout.
+
+**Test scenarios:**
+
+- The new tab renders correct lifetime totals for a user with existing completions.
+- The new tab renders "no completions yet" (or equivalent) state correctly for a user with zero entries.
+- Each history entry displays the name of the trip it belongs to.
+- Clicking delete on an entry requires confirmation before the request fires; canceling the confirmation leaves the entry untouched.
+- Confirming delete removes the entry from the visible list and the displayed totals decrease accordingly, applied from the `DELETE` response without a separate re-fetch (covers AE5).
+- Toggling sharing on, reloading the page, and confirming the toggle state persists (covers AE4's persistence half).
+- Test expectation: this plan does not add a public surface that reads the sharing toggle, so there is no test for "another user sees shared totals" — that's explicitly out of scope (see Scope Boundaries) and belongs to a future plan.
+
+**Verification:** Log a few completions across entity types, confirm the profile tab reflects correct totals, delete one, confirm totals and the list both update, then toggle and reload to confirm the sharing preference persists.
+
+---
+
+## Verification Contract
+
+- **Type checking:** `npm run check` must pass after schema and route changes (TypeScript strict mode, `svelte-check`).
+- **Linting:** `npm run lint` must pass.
+- **Unit tests:** `npm run test:unit` — add Vitest coverage for the recompute-aggregate logic (U2/U3) and the entity/nights validation logic (U2), since these are the units with the most edge-case surface.
+- **E2E tests:** `npm run test:e2e` — extend Playwright coverage to cover the log → view totals → delete → totals update round trip (U5/U6), following the existing e2e patterns already covering favorites/ratings flows.
+- **Migration:** `npm run db:migrate` must apply cleanly against a preview database before this ships, consistent with the repo's CI gating (migrations run before deploy in both `deploy-preview.yml` and `deploy-prod.yml`).
+- No `release:validate` or behavioral-skill-evaluation gate applies — this is a standard CRUD feature, not an agent/skill-facing change.
+
+## Definition of Done
+
+**Global:**
+
+- All six implementation units complete and merged.
+- `npm run check`, `npm run lint`, `npm run test:unit`, and `npm run test:e2e` all pass.
+- `npm run db:migrate` has been run against the preview environment and the new tables/column exist as designed.
+- No dead-end or experimental code from abandoned approaches remains in the diff (e.g., no leftover discriminator-enum attempt if the three-FK shape was chosen after trying alternatives during implementation).
+
+**Per-unit:**
+
+- U1: migration applies cleanly; CHECK constraint and non-unique indexes verified via the schema-level test scenarios.
+- U2: all POST test scenarios pass, including the entity-validation and nights-validation error paths.
+- U3: GET/DELETE scoping and 403/404 test scenarios pass.
+- U4: my-stats returns correct data for both zero-completion and populated users; sharing toggle round-trips.
+- U5: button behavior verified manually or via e2e for all three entity types, including the camping nights-form validation.
+- U6: profile tab renders totals/history correctly and reflects deletions and sharing-toggle changes.

--- a/e2e/completions.user.spec.ts
+++ b/e2e/completions.user.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "./fixtures/base-test";
+import { getHikeId, getCampingId } from "./fixtures/helpers";
+
+test.describe("Trip completion log – authenticated user", () => {
+  test("logs a hike as completed and increments the visible count", async ({ page }) => {
+    const hikeId = getHikeId();
+    await page.goto(`/hikes/${hikeId}`);
+    await page.waitForLoadState("load");
+
+    const logBtn = page.getByRole("button", { name: /Log as completed/ });
+    await expect(logBtn).toBeVisible();
+
+    const initialText = (await logBtn.textContent()) ?? "";
+    const initialMatch = initialText.match(/logged (\d+) time/);
+    const initialCount = initialMatch ? Number(initialMatch[1]) : 0;
+
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/completions") &&
+          r.request().method() === "POST" &&
+          r.status() < 300
+      ),
+      logBtn.click(),
+    ]);
+
+    await expect(page.getByText(`logged ${initialCount + 1} time`)).toBeVisible();
+  });
+
+  test("clicking the log button repeatedly creates independent entries, not a toggle", async ({
+    page,
+  }) => {
+    const hikeId = getHikeId();
+    await page.goto(`/hikes/${hikeId}`);
+    await page.waitForLoadState("load");
+
+    const logBtn = page.getByRole("button", { name: /Log as completed/ });
+    const initialText = (await logBtn.textContent()) ?? "";
+    const initialMatch = initialText.match(/logged (\d+) time/);
+    const initialCount = initialMatch ? Number(initialMatch[1]) : 0;
+
+    for (let i = 1; i <= 2; i++) {
+      await Promise.all([
+        page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/completions") &&
+            r.request().method() === "POST" &&
+            r.status() < 300
+        ),
+        logBtn.click(),
+      ]);
+      await expect(page.getByText(`logged ${initialCount + i} time`)).toBeVisible();
+    }
+  });
+
+  test("camping detail page requires nights before logging, and rejects out-of-range input", async ({
+    page,
+  }) => {
+    const campingId = getCampingId();
+    await page.goto(`/camping/${campingId}`);
+    await page.waitForLoadState("load");
+
+    const logBtn = page.getByRole("button", { name: /Log as completed/ });
+    await logBtn.click();
+
+    const nightsInput = page.locator("#nights-stayed");
+    await expect(nightsInput).toBeVisible();
+
+    // Out-of-range input is rejected client-side, no request fires
+    await nightsInput.fill("0");
+    await page.getByRole("button", { name: "Log completion" }).click();
+    await expect(page.getByText("Enter a whole number of nights between 1 and 90")).toBeVisible();
+
+    // Valid input succeeds and collapses the form
+    await nightsInput.fill("3");
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/completions") &&
+          r.request().method() === "POST" &&
+          r.status() < 300
+      ),
+      page.getByRole("button", { name: "Log completion" }).click(),
+    ]);
+    await expect(nightsInput).not.toBeVisible();
+  });
+
+  test("logged completions appear in the My Adventures tab and can be deleted with confirmation", async ({
+    page,
+  }) => {
+    const hikeId = getHikeId();
+
+    // Log a completion to guarantee at least one history entry exists
+    await page.goto(`/hikes/${hikeId}`);
+    await page.waitForLoadState("load");
+    const logBtn = page.getByRole("button", { name: /Log as completed/ });
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/completions") &&
+          r.request().method() === "POST" &&
+          r.status() < 300
+      ),
+      logBtn.click(),
+    ]);
+
+    // Switch to the My Adventures tab on the profile page
+    await page.goto("/profile");
+    await page.waitForLoadState("load");
+    await page.locator("#tab-adventures").dispatchEvent("click");
+
+    await expect(page.getByText("Trips Logged")).toBeVisible();
+    const deleteButtons = page.getByRole("button", { name: "Delete this completion" });
+    await expect(deleteButtons.first()).toBeVisible();
+
+    const historyCountBefore = await deleteButtons.count();
+
+    // First click asks for confirmation, doesn't delete yet
+    await deleteButtons.first().click();
+    await expect(page.getByText("Remove and update totals?")).toBeVisible();
+
+    // Confirm deletes it
+    await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes("/api/completions/") && r.request().method() === "DELETE"
+      ),
+      page.getByRole("button", { name: "Confirm" }).click(),
+    ]);
+
+    await expect(page.getByRole("button", { name: "Delete this completion" })).toHaveCount(
+      historyCountBefore - 1
+    );
+  });
+});

--- a/src/lib/components/LogCompletionButton.svelte
+++ b/src/lib/components/LogCompletionButton.svelte
@@ -27,10 +27,11 @@
       if (hikeId) params.append("hike_id", hikeId);
       if (campingSiteId) params.append("camping_site_id", campingSiteId);
       if (backpackingId) params.append("backpacking_id", backpackingId);
+      params.append("count_only", "true");
       const response = await fetch(`/api/completions?${params}`);
       if (!response.ok) return;
       const data = await response.json();
-      count = Array.isArray(data.completions) ? data.completions.length : 0;
+      count = typeof data.count === "number" ? data.count : 0;
     } catch (err) {
       console.error("Error fetching completion count:", err);
     }
@@ -72,6 +73,11 @@
         showCampingForm = false;
         nightsInput = "";
       }
+
+      // Reconcile with the authoritative count rather than trusting the
+      // optimistic increment indefinitely (it would otherwise drift after
+      // deletions elsewhere, e.g. the My Adventures history).
+      await fetchCount();
     } catch (err) {
       console.error("Error logging completion:", err);
       count = previousCount; // rollback

--- a/src/lib/components/LogCompletionButton.svelte
+++ b/src/lib/components/LogCompletionButton.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { CheckCircle2 } from "lucide-svelte";
+
+  export let hikeId: string | null = null;
+  export let campingSiteId: string | null = null;
+  export let backpackingId: string | null = null;
+  export let userId: string | null = null;
+
+  const isCamping = !!campingSiteId;
+
+  let count = 0;
+  let submitting = false;
+  let errorMessage: string | null = null;
+  let showCampingForm = false;
+  let nightsInput = "";
+  let nightsError: string | null = null;
+
+  onMount(async () => {
+    if (!userId) return;
+    await fetchCount();
+  });
+
+  async function fetchCount() {
+    try {
+      const params = new URLSearchParams();
+      if (hikeId) params.append("hike_id", hikeId);
+      if (campingSiteId) params.append("camping_site_id", campingSiteId);
+      if (backpackingId) params.append("backpacking_id", backpackingId);
+      const response = await fetch(`/api/completions?${params}`);
+      if (!response.ok) return;
+      const data = await response.json();
+      count = Array.isArray(data.completions) ? data.completions.length : 0;
+    } catch (err) {
+      console.error("Error fetching completion count:", err);
+    }
+  }
+
+  function handleClick() {
+    if (!userId) {
+      window.location.href = "/login";
+      return;
+    }
+    if (submitting) return;
+
+    if (isCamping) {
+      showCampingForm = !showCampingForm;
+      nightsError = null;
+      errorMessage = null;
+      return;
+    }
+
+    void logCompletion();
+  }
+
+  async function logCompletion(nights?: number) {
+    submitting = true;
+    errorMessage = null;
+
+    const previousCount = count;
+    count = count + 1; // optimistic
+
+    try {
+      const response = await fetch("/api/completions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hikeId, campingSiteId, backpackingId, nights }),
+      });
+      if (!response.ok) throw new Error("Failed to log completion");
+
+      if (isCamping) {
+        showCampingForm = false;
+        nightsInput = "";
+      }
+    } catch (err) {
+      console.error("Error logging completion:", err);
+      count = previousCount; // rollback
+      errorMessage = "Couldn't log this trip — try again";
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function submitCampingForm() {
+    const parsed = Number(nightsInput);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 90) {
+      nightsError = "Enter a whole number of nights between 1 and 90";
+      return;
+    }
+    nightsError = null;
+    void logCompletion(parsed);
+  }
+</script>
+
+<div class="inline-flex flex-col items-start gap-1">
+  <button
+    type="button"
+    on:click={handleClick}
+    disabled={submitting}
+    aria-disabled={!userId || undefined}
+    aria-describedby={!userId ? "log-completion-login-hint" : undefined}
+    class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-emerald-300 text-emerald-700 bg-white hover:bg-emerald-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors {!userId
+      ? 'opacity-50 cursor-not-allowed'
+      : ''}"
+  >
+    <CheckCircle2 size={15} />
+    {submitting ? "Logging…" : "Log as completed"}
+    {#if count > 0}
+      <span class="text-xs text-emerald-600">(logged {count} {count === 1 ? "time" : "times"})</span
+      >
+    {/if}
+  </button>
+
+  {#if !userId}
+    <span id="log-completion-login-hint" class="sr-only">Log in to track completed trips</span>
+  {/if}
+
+  {#if errorMessage}
+    <p class="text-xs text-red-600" role="alert">{errorMessage}</p>
+  {/if}
+
+  {#if isCamping && showCampingForm}
+    <div class="mt-1 p-3 border border-gray-200 rounded-lg bg-gray-50 space-y-2">
+      <label for="nights-stayed" class="block text-xs font-medium text-gray-700">
+        Nights stayed
+      </label>
+      <input
+        id="nights-stayed"
+        type="number"
+        min="1"
+        max="90"
+        step="1"
+        bind:value={nightsInput}
+        aria-describedby={nightsError ? "nights-stayed-error" : undefined}
+        class="w-24 px-2 py-1 text-sm border border-gray-300 rounded"
+      />
+      {#if nightsError}
+        <p id="nights-stayed-error" class="text-xs text-red-600" role="alert">{nightsError}</p>
+      {/if}
+      <div class="flex gap-2">
+        <button
+          type="button"
+          on:click={submitCampingForm}
+          disabled={submitting}
+          class="px-2.5 py-1 text-xs font-medium rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {submitting ? "Logging…" : "Log completion"}
+        </button>
+        <button
+          type="button"
+          on:click={() => {
+            showCampingForm = false;
+            nightsError = null;
+          }}
+          disabled={submitting}
+          class="px-2.5 py-1 text-xs font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/MyAdventures.svelte
+++ b/src/lib/components/MyAdventures.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { enhance } from "$app/forms";
+  import { Trash2, Shield } from "lucide-svelte";
+
+  export let initialShareCompletionStats: boolean;
+
+  type CompletionEntry = {
+    id: string;
+    entityName: string | null;
+    entitySlug: string | null;
+    distance: string | null;
+    nights: number | null;
+    createdAt: string;
+  };
+
+  let stats: { totalMiles: string; totalNights: number; tripCount: number } | null = null;
+  let history: CompletionEntry[] = [];
+  let loading = true;
+  let confirmingId: string | null = null;
+  let deletingId: string | null = null;
+  let isSavingSharing = false;
+
+  onMount(loadAdventures);
+
+  async function loadAdventures() {
+    loading = true;
+    try {
+      const [statsRes, historyRes] = await Promise.all([
+        fetch("/api/completions/my-stats"),
+        fetch("/api/completions"),
+      ]);
+      if (statsRes.ok) stats = await statsRes.json();
+      if (historyRes.ok) {
+        const data = await historyRes.json();
+        history = data.completions ?? [];
+      }
+    } catch (err) {
+      console.error("Error loading adventures:", err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function confirmDelete(id: string) {
+    deletingId = id;
+    try {
+      const response = await fetch(`/api/completions/${id}`, { method: "DELETE" });
+      if (!response.ok) throw new Error("Failed to delete completion");
+      const data = await response.json();
+      history = history.filter((entry) => entry.id !== id);
+      stats = {
+        totalMiles: data.stats.totalMiles,
+        totalNights: data.stats.totalNights,
+        tripCount: data.stats.tripCount,
+      };
+    } catch (err) {
+      console.error("Error deleting completion:", err);
+    } finally {
+      deletingId = null;
+      confirmingId = null;
+    }
+  }
+</script>
+
+<div class="space-y-6">
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+    <div class="rounded-xl p-5 bg-stone-50 border border-stone-100">
+      <p class="text-xs font-bold text-stone-400 uppercase tracking-widest mb-2">Miles Hiked</p>
+      <p class="text-2xl font-black text-stone-900">
+        {stats ? Math.round(Number(stats.totalMiles) * 10) / 10 : "—"}
+      </p>
+    </div>
+    <div class="rounded-xl p-5 bg-stone-50 border border-stone-100">
+      <p class="text-xs font-bold text-stone-400 uppercase tracking-widest mb-2">Nights Camped</p>
+      <p class="text-2xl font-black text-stone-900">{stats ? stats.totalNights : "—"}</p>
+    </div>
+    <div class="rounded-xl p-5 bg-stone-50 border border-stone-100">
+      <p class="text-xs font-bold text-stone-400 uppercase tracking-widest mb-2">Trips Logged</p>
+      <p class="text-2xl font-black text-stone-900">{stats ? stats.tripCount : "—"}</p>
+    </div>
+  </div>
+
+  <div class="pt-4 border-t border-stone-100">
+    <h3 class="text-xs font-bold text-stone-400 uppercase tracking-widest mb-4">History</h3>
+
+    {#if loading}
+      <p class="text-sm text-stone-400">Loading…</p>
+    {:else if history.length === 0}
+      <p class="text-sm text-stone-400">No completions logged yet.</p>
+    {:else}
+      <ul class="space-y-2">
+        {#each history as entry (entry.id)}
+          <li
+            class="flex items-center justify-between rounded-xl p-3 bg-stone-50 border border-stone-100"
+          >
+            <div>
+              <p class="text-sm font-semibold text-stone-900">
+                {entry.entityName ?? "Unknown trip"}
+              </p>
+              <p class="text-xs text-stone-400">
+                {new Date(entry.createdAt).toLocaleDateString()}
+                {#if entry.distance}
+                  · {Math.round(Number(entry.distance) * 10) / 10} mi
+                {/if}
+                {#if entry.nights}
+                  · {entry.nights} {entry.nights === 1 ? "night" : "nights"}
+                {/if}
+              </p>
+            </div>
+            {#if confirmingId === entry.id}
+              <div class="flex items-center gap-2">
+                <span class="text-xs text-stone-500">Remove and update totals?</span>
+                <button
+                  type="button"
+                  on:click={() => confirmDelete(entry.id)}
+                  disabled={deletingId === entry.id}
+                  class="px-2.5 py-1 text-xs font-medium rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+                >
+                  {deletingId === entry.id ? "Removing…" : "Confirm"}
+                </button>
+                <button
+                  type="button"
+                  on:click={() => (confirmingId = null)}
+                  class="px-2.5 py-1 text-xs font-medium rounded border border-stone-300 text-stone-600 hover:bg-stone-100"
+                >
+                  Cancel
+                </button>
+              </div>
+            {:else}
+              <button
+                type="button"
+                on:click={() => (confirmingId = entry.id)}
+                aria-label="Delete this completion"
+                class="p-1.5 rounded-lg text-stone-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+              >
+                <Trash2 size={15} />
+              </button>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+
+  <div
+    class="rounded-xl p-4 bg-stone-50 border border-stone-100 flex items-start gap-4 pt-4 border-t border-stone-100"
+  >
+    <div class="flex-1">
+      <div class="flex items-center gap-2 mb-1">
+        <Shield size={13} class="text-stone-400" />
+        <p class="text-xs font-bold text-stone-500 uppercase tracking-widest">Share My Totals</p>
+      </div>
+      <p class="text-xs text-stone-400">
+        When on, your lifetime totals may be shown on your profile. Off by default.
+      </p>
+    </div>
+    <form
+      method="POST"
+      action="/profile?/saveSharingPreference"
+      use:enhance={() => {
+        isSavingSharing = true;
+        return async ({ update }) => {
+          await update();
+          isSavingSharing = false;
+        };
+      }}
+      on:submit={() => (isSavingSharing = true)}
+    >
+      <label class="relative inline-flex items-center cursor-pointer mt-0.5">
+        <input
+          type="checkbox"
+          name="shareCompletionStats"
+          class="sr-only peer"
+          checked={initialShareCompletionStats}
+          disabled={isSavingSharing}
+          on:change={(e) => e.currentTarget.form?.requestSubmit()}
+        />
+        <div
+          class="w-10 h-6 bg-stone-200 peer-focus:ring-2 peer-focus:ring-emerald-400 rounded-full peer peer-checked:bg-emerald-500 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all"
+        ></div>
+      </label>
+    </form>
+  </div>
+</div>

--- a/src/lib/components/MyAdventures.svelte
+++ b/src/lib/components/MyAdventures.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { enhance } from "$app/forms";
   import { Trash2, Shield } from "lucide-svelte";
 
   export let initialShareCompletionStats: boolean;
+
+  let shareCompletionStats = initialShareCompletionStats;
+  let isSavingSharing = false;
+  let sharingError: string | null = null;
 
   type CompletionEntry = {
     id: string;
@@ -19,7 +22,6 @@
   let loading = true;
   let confirmingId: string | null = null;
   let deletingId: string | null = null;
-  let isSavingSharing = false;
 
   onMount(loadAdventures);
 
@@ -59,6 +61,32 @@
     } finally {
       deletingId = null;
       confirmingId = null;
+    }
+  }
+
+  async function toggleSharing() {
+    if (isSavingSharing) return;
+
+    // bind:checked already applied the click to shareCompletionStats by the
+    // time this change handler runs, so that IS the optimistic "next" value.
+    const next = shareCompletionStats;
+    const previous = !next;
+    isSavingSharing = true;
+    sharingError = null;
+
+    try {
+      const response = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shareCompletionStats: next }),
+      });
+      if (!response.ok) throw new Error("Failed to save sharing preference");
+    } catch (err) {
+      console.error("Error saving sharing preference:", err);
+      shareCompletionStats = previous; // rollback
+      sharingError = "Couldn't save — try again";
+    } finally {
+      isSavingSharing = false;
     }
   }
 </script>
@@ -154,32 +182,23 @@
       <p class="text-xs text-stone-400">
         When on, your lifetime totals may be shown on your profile. Off by default.
       </p>
+      {#if sharingError}
+        <p class="text-xs text-red-600 mt-1" role="alert">{sharingError}</p>
+      {/if}
     </div>
-    <form
-      method="POST"
-      action="/profile?/saveSharingPreference"
-      use:enhance={() => {
-        isSavingSharing = true;
-        return async ({ update }) => {
-          await update();
-          isSavingSharing = false;
-        };
-      }}
-      on:submit={() => (isSavingSharing = true)}
-    >
+    <div>
       <label class="relative inline-flex items-center cursor-pointer mt-0.5">
         <input
           type="checkbox"
-          name="shareCompletionStats"
           class="sr-only peer"
-          checked={initialShareCompletionStats}
+          bind:checked={shareCompletionStats}
           disabled={isSavingSharing}
-          on:change={(e) => e.currentTarget.form?.requestSubmit()}
+          on:change={toggleSharing}
         />
         <div
           class="w-10 h-6 bg-stone-200 peer-focus:ring-2 peer-focus:ring-emerald-400 rounded-full peer peer-checked:bg-emerald-500 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all"
         ></div>
       </label>
-    </form>
+    </div>
   </div>
 </div>

--- a/src/lib/db/schemas/completion-stats.ts
+++ b/src/lib/db/schemas/completion-stats.ts
@@ -1,0 +1,11 @@
+import { pgTable, text, numeric, integer } from "drizzle-orm/pg-core";
+
+export const completionStats = pgTable("completion_stats", {
+  userId: text("user_id").primaryKey(),
+  totalMiles: numeric("total_miles").default("0").notNull(),
+  totalNights: integer("total_nights").default(0).notNull(),
+  tripCount: integer("trip_count").default(0).notNull(),
+});
+
+export type CompletionStats = typeof completionStats.$inferSelect;
+export type NewCompletionStats = typeof completionStats.$inferInsert;

--- a/src/lib/db/schemas/completions.ts
+++ b/src/lib/db/schemas/completions.ts
@@ -1,0 +1,70 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  numeric,
+  integer,
+  check,
+  index,
+} from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+import { hikes } from "./hikes";
+import { campingSites } from "./camping-sites";
+import { backpacking } from "./backpacking";
+import { distanceUnitEnum, durationUnitEnum, elevationUnitEnum } from "./enums";
+
+export const tripCompletions = pgTable(
+  "trip_completions",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id").notNull(),
+    hikeId: uuid("hike_id").references(() => hikes.id, { onDelete: "cascade" }),
+    campingSiteId: uuid("camping_site_id").references(() => campingSites.id, {
+      onDelete: "cascade",
+    }),
+    backpackingId: uuid("backpacking_id").references(() => backpacking.id, {
+      onDelete: "cascade",
+    }),
+    distance: numeric("distance"),
+    distanceUnit: distanceUnitEnum("distance_unit"),
+    duration: numeric("duration"),
+    durationUnit: durationUnitEnum("duration_unit"),
+    elevation: numeric("elevation"),
+    elevationUnit: elevationUnitEnum("elevation_unit"),
+    nights: integer("nights"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    entityCheck: check(
+      "trip_completions_entity_check",
+      sql`(${table.hikeId} IS NOT NULL AND ${table.campingSiteId} IS NULL AND ${table.backpackingId} IS NULL) OR (${table.hikeId} IS NULL AND ${table.campingSiteId} IS NOT NULL AND ${table.backpackingId} IS NULL) OR (${table.hikeId} IS NULL AND ${table.campingSiteId} IS NULL AND ${table.backpackingId} IS NOT NULL)`
+    ),
+    nightsCheck: check(
+      "trip_completions_nights_check",
+      sql`${table.nights} IS NULL OR (${table.nights} >= 1 AND ${table.nights} <= 90)`
+    ),
+    userIdIdx: index("trip_completions_user_id_idx").on(table.userId),
+    hikeIdIdx: index("trip_completions_hike_id_idx").on(table.hikeId),
+    campingSiteIdIdx: index("trip_completions_camping_site_id_idx").on(table.campingSiteId),
+    backpackingIdIdx: index("trip_completions_backpacking_id_idx").on(table.backpackingId),
+  })
+);
+
+export const tripCompletionsRelations = relations(tripCompletions, ({ one }) => ({
+  hike: one(hikes, {
+    fields: [tripCompletions.hikeId],
+    references: [hikes.id],
+  }),
+  campingSite: one(campingSites, {
+    fields: [tripCompletions.campingSiteId],
+    references: [campingSites.id],
+  }),
+  backpacking: one(backpacking, {
+    fields: [tripCompletions.backpackingId],
+    references: [backpacking.id],
+  }),
+}));
+
+export type TripCompletion = typeof tripCompletions.$inferSelect;
+export type NewTripCompletion = typeof tripCompletions.$inferInsert;

--- a/src/lib/db/schemas/index.ts
+++ b/src/lib/db/schemas/index.ts
@@ -17,5 +17,7 @@ export * from "./ratings";
 export * from "./rating-aggregates";
 export * from "./image-flags";
 export * from "./user-profiles";
+export * from "./completions";
+export * from "./completion-stats";
 export * from "./series";
 export * from "./posts";

--- a/src/lib/db/schemas/user-profiles.ts
+++ b/src/lib/db/schemas/user-profiles.ts
@@ -8,6 +8,7 @@ export const userProfiles = pgTable("user_profiles", {
   unitType: text("unit_type"),
   unitNumber: text("unit_number"),
   showUnitInfo: boolean("show_unit_info").default(true).notNull(),
+  shareCompletionStats: boolean("share_completion_stats").default(false).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/src/lib/server/completions.ts
+++ b/src/lib/server/completions.ts
@@ -1,0 +1,39 @@
+import { db } from "$lib/db";
+import { sql } from "drizzle-orm";
+
+// Atomically recompute and upsert a user's lifetime completion totals using a
+// single INSERT ... SELECT ... ON CONFLICT DO UPDATE statement, mirroring
+// updateRatingAggregates() in /api/ratings. Sums are COALESCEd to 0 (SUM over
+// an all-NULL group, e.g. a camping-only user, returns NULL in Postgres, not
+// 0), and kilometers-denominated distance rows are converted to miles before
+// summing since distance_unit is a per-row snapshot, not a canonical unit.
+export async function recomputeCompletionStats(userId: string) {
+  const result = await db.execute(sql`
+    INSERT INTO completion_stats (user_id, total_miles, total_nights, trip_count)
+    SELECT
+      ${userId}::text,
+      COALESCE(SUM(
+        CASE
+          WHEN distance IS NULL THEN 0
+          WHEN distance_unit = 'kilometers' THEN distance::numeric * 0.621371
+          ELSE distance::numeric
+        END
+      ), 0),
+      COALESCE(SUM(COALESCE(nights, 0)), 0),
+      COUNT(*)::integer
+    FROM trip_completions
+    WHERE user_id = ${userId}::text
+    ON CONFLICT (user_id) DO UPDATE SET
+      total_miles = EXCLUDED.total_miles,
+      total_nights = EXCLUDED.total_nights,
+      trip_count = EXCLUDED.trip_count
+    RETURNING user_id, total_miles, total_nights, trip_count
+  `);
+
+  return result.rows[0] as unknown as {
+    user_id: string;
+    total_miles: string;
+    total_nights: number;
+    trip_count: number;
+  };
+}

--- a/src/lib/server/entity-refs.ts
+++ b/src/lib/server/entity-refs.ts
@@ -1,0 +1,24 @@
+import { error } from "@sveltejs/kit";
+
+type EntityRefs = {
+  hikeId?: unknown;
+  campingSiteId?: unknown;
+  backpackingId?: unknown;
+};
+
+// Hikes, camping sites, and backpacking trips are referenced polymorphically
+// (favorites, ratings, notes, alterations, trip completions) via three
+// nullable FKs where exactly one must be set. Shared here so the two-branch
+// check (missing vs. more-than-one) isn't reimplemented at every call site.
+export function requireExactlyOneEntityRef(
+  { hikeId, campingSiteId, backpackingId }: EntityRefs,
+  messages: { missing: string; tooMany: string }
+): void {
+  const count = [hikeId, campingSiteId, backpackingId].filter(Boolean).length;
+  if (count === 0) {
+    throw error(400, messages.missing);
+  }
+  if (count > 1) {
+    throw error(400, messages.tooMany);
+  }
+}

--- a/src/lib/server/rate-limit.ts
+++ b/src/lib/server/rate-limit.ts
@@ -104,6 +104,11 @@ export const ROUTE_TIERS: Record<string, Tier> = {
   // user-keyed "write" bucket better than the IP-keyed "read" bucket.
   "/api/ratings/my-rating": "write",
   "/api/alterations/[id]": "write",
+  // Whole route: GET is always scoped to the caller's own completions
+  // (never public), same reasoning as /api/ratings/my-rating above.
+  "/api/completions": "write",
+  "/api/completions/[id]": "write",
+  "/api/completions/my-stats": "write",
 
   // --- privileged tier: whole route, admin/moderator-only ---
   "/api/moderation": "privileged",

--- a/src/routes/api/alterations/+server.ts
+++ b/src/routes/api/alterations/+server.ts
@@ -4,6 +4,7 @@ import { db } from "$lib/db";
 import { alterations } from "$lib/db/schemas";
 import { eq, and, desc } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
+import { requireExactlyOneEntityRef } from "$lib/server/entity-refs";
 import { addToModerationQueue } from "$lib/moderation";
 import { isAllowedAlterationField } from "$lib/allowed-fields";
 import { parseLimit, parseOffset } from "$lib/utils/pagination";
@@ -54,14 +55,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     throw error(400, "fieldName and newValue are required");
   }
 
-  if (!hikeId && !campingSiteId && !backpackingId) {
-    throw error(400, "Either hikeId, campingSiteId, or backpackingId is required");
-  }
-
-  const entityCount = [hikeId, campingSiteId, backpackingId].filter(Boolean).length;
-  if (entityCount > 1) {
-    throw error(400, "Cannot alter more than one entity at once");
-  }
+  requireExactlyOneEntityRef(
+    { hikeId, campingSiteId, backpackingId },
+    {
+      missing: "Either hikeId, campingSiteId, or backpackingId is required",
+      tooMany: "Cannot alter more than one entity at once",
+    }
+  );
 
   // Validate fieldName against entity-specific allowlist to prevent
   // privilege escalation via fields like 'status', 'featured', 'createdBy'

--- a/src/routes/api/backpacking/[id]/+server.ts
+++ b/src/routes/api/backpacking/[id]/+server.ts
@@ -1,13 +1,22 @@
 import { json, error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { db } from "$lib/db";
-import { backpacking, addresses, ratingAggregates, files, councils, moderationQueue } from "$lib/db/schemas";
+import {
+  backpacking,
+  addresses,
+  ratingAggregates,
+  files,
+  councils,
+  moderationQueue,
+  tripCompletions,
+} from "$lib/db/schemas";
 import { eq, sql, and } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
 import { isPrivilegedUser } from "$lib/auth/helpers";
 import { deleteFile } from "$lib/storage/blob";
 import { getAttribution } from "$lib/server/attribution";
 import { generateUniqueSlug } from "$lib/server/slug";
+import { recomputeCompletionStats } from "$lib/server/completions";
 
 export const GET: RequestHandler = async ({ params, locals }) => {
   const rows = await db
@@ -221,15 +230,22 @@ export const DELETE: RequestHandler = async (event) => {
     await db.delete(files).where(eq(files.entityId, entry.id));
   }
 
+  // Capture which users logged completions against this trip before the
+  // delete cascades away their trip_completions rows, so lifetime totals can
+  // be recomputed afterward instead of going stale.
+  const affectedUsers = await db
+    .selectDistinct({ userId: tripCompletions.userId })
+    .from(tripCompletions)
+    .where(eq(tripCompletions.backpackingId, entry.id));
+
   await db.delete(backpacking).where(eq(backpacking.id, entry.id));
   await db
     .delete(moderationQueue)
     .where(
-      and(
-        eq(moderationQueue.entityType, "backpacking"),
-        eq(moderationQueue.entityId, entry.id)
-      )
+      and(eq(moderationQueue.entityType, "backpacking"), eq(moderationQueue.entityId, entry.id))
     );
+
+  await Promise.all(affectedUsers.map((u) => recomputeCompletionStats(u.userId)));
 
   return json({ success: true });
 };

--- a/src/routes/api/camping-sites/[id]/+server.ts
+++ b/src/routes/api/camping-sites/[id]/+server.ts
@@ -1,13 +1,22 @@
 import { json, error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { db } from "$lib/db";
-import { campingSites, addresses, ratingAggregates, files, councils, moderationQueue } from "$lib/db/schemas";
+import {
+  campingSites,
+  addresses,
+  ratingAggregates,
+  files,
+  councils,
+  moderationQueue,
+  tripCompletions,
+} from "$lib/db/schemas";
 import { eq, sql, and } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
 import { isPrivilegedUser } from "$lib/auth/helpers";
 import { deleteFile } from "$lib/storage/blob";
 import { getAttribution } from "$lib/server/attribution";
 import { generateUniqueSlug } from "$lib/server/slug";
+import { recomputeCompletionStats } from "$lib/server/completions";
 
 export const GET: RequestHandler = async ({ params, locals }) => {
   const rows = await db
@@ -216,6 +225,14 @@ export const DELETE: RequestHandler = async (event) => {
     await db.delete(files).where(eq(files.entityId, campingSite.id));
   }
 
+  // Capture which users logged completions against this camping site before
+  // the delete cascades away their trip_completions rows, so lifetime totals
+  // can be recomputed afterward instead of going stale.
+  const affectedUsers = await db
+    .selectDistinct({ userId: tripCompletions.userId })
+    .from(tripCompletions)
+    .where(eq(tripCompletions.campingSiteId, campingSite.id));
+
   await db.delete(campingSites).where(eq(campingSites.id, campingSite.id));
   await db
     .delete(moderationQueue)
@@ -225,6 +242,8 @@ export const DELETE: RequestHandler = async (event) => {
         eq(moderationQueue.entityId, campingSite.id)
       )
     );
+
+  await Promise.all(affectedUsers.map((u) => recomputeCompletionStats(u.userId)));
 
   return json({ success: true });
 };

--- a/src/routes/api/completions/+server.ts
+++ b/src/routes/api/completions/+server.ts
@@ -1,0 +1,122 @@
+import { json, error } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { db } from "$lib/db";
+import { tripCompletions, hikes, backpacking } from "$lib/db/schemas";
+import { eq, and, desc } from "drizzle-orm";
+import { requireAuth } from "$lib/auth/middleware";
+import { parseLimit, parseOffset } from "$lib/utils/pagination";
+import { recomputeCompletionStats } from "$lib/server/completions";
+
+// POST /api/completions - Log a hike, camping site, or backpacking trip as completed
+export const POST: RequestHandler = async ({ request, locals }) => {
+  const user = requireAuth({ locals } as any);
+
+  const body = await request.json();
+  const { hikeId, campingSiteId, backpackingId, nights } = body;
+
+  const entityCount = [hikeId, campingSiteId, backpackingId].filter(Boolean).length;
+  if (entityCount !== 1) {
+    throw error(400, "Exactly one of hikeId, campingSiteId, or backpackingId is required");
+  }
+
+  let distance: string | null = null;
+  let distanceUnit: "miles" | "kilometers" | null = null;
+  let duration: string | null = null;
+  let durationUnit: "minutes" | "hours" | null = null;
+  let elevation: string | null = null;
+  let elevationUnit: "feet" | "meters" | null = null;
+  let validatedNights: number | null = null;
+
+  if (hikeId) {
+    const listing = await db.query.hikes.findFirst({ where: eq(hikes.id, hikeId) });
+    if (!listing) throw error(404, "Hike not found");
+    distance = listing.distance;
+    distanceUnit = listing.distanceUnit;
+    duration = listing.duration;
+    durationUnit = listing.durationUnit;
+    elevation = listing.elevation;
+    elevationUnit = listing.elevationUnit;
+  } else if (backpackingId) {
+    const listing = await db.query.backpacking.findFirst({
+      where: eq(backpacking.id, backpackingId),
+    });
+    if (!listing) throw error(404, "Backpacking trip not found");
+    distance = listing.distance;
+    distanceUnit = listing.distanceUnit;
+    duration = listing.duration;
+    durationUnit = listing.durationUnit;
+    elevation = listing.elevation;
+    elevationUnit = listing.elevationUnit;
+  } else if (campingSiteId) {
+    if (!Number.isInteger(nights) || nights < 1 || nights > 90) {
+      throw error(
+        400,
+        "nights is required for camping completions and must be an integer between 1 and 90"
+      );
+    }
+    validatedNights = nights;
+  }
+
+  const [result] = await db
+    .insert(tripCompletions)
+    .values({
+      userId: user.id,
+      hikeId: hikeId || null,
+      campingSiteId: campingSiteId || null,
+      backpackingId: backpackingId || null,
+      distance,
+      distanceUnit,
+      duration,
+      durationUnit,
+      elevation,
+      elevationUnit,
+      nights: validatedNights,
+    })
+    .returning();
+
+  await recomputeCompletionStats(user.id);
+
+  return json(result, { status: 201 });
+};
+
+// GET /api/completions - List the caller's own completion log entries.
+// Optional entity filters narrow to one listing; with no filter, returns the
+// caller's full history (paginated), newest first, joined to each entity's name.
+export const GET: RequestHandler = async ({ url, locals }) => {
+  const user = requireAuth({ locals } as any);
+
+  const hikeId = url.searchParams.get("hike_id");
+  const campingSiteId = url.searchParams.get("camping_site_id");
+  const backpackingId = url.searchParams.get("backpacking_id");
+  const limit = parseLimit(url.searchParams.get("limit"));
+  const offset = parseOffset(url.searchParams.get("offset"));
+
+  const conditions = [eq(tripCompletions.userId, user.id)];
+  if (hikeId) conditions.push(eq(tripCompletions.hikeId, hikeId));
+  if (campingSiteId) conditions.push(eq(tripCompletions.campingSiteId, campingSiteId));
+  if (backpackingId) conditions.push(eq(tripCompletions.backpackingId, backpackingId));
+
+  const results = await db.query.tripCompletions.findMany({
+    where: and(...conditions),
+    orderBy: [desc(tripCompletions.createdAt)],
+    limit,
+    offset,
+    with: {
+      hike: { columns: { name: true, slug: true } },
+      campingSite: { columns: { name: true, slug: true } },
+      backpacking: { columns: { name: true, slug: true } },
+    },
+  });
+
+  const withEntity = results.map((r) => {
+    const entity = r.hike || r.campingSite || r.backpacking || null;
+    const { hike: _hike, campingSite: _campingSite, backpacking: _backpacking, ...rest } = r;
+    return {
+      ...rest,
+      entityName: entity?.name ?? null,
+      entitySlug: entity?.slug ?? null,
+    };
+  });
+
+  return json({ completions: withEntity }, { headers: { "Cache-Control": "no-store" } });
+};

--- a/src/routes/api/completions/+server.ts
+++ b/src/routes/api/completions/+server.ts
@@ -1,23 +1,25 @@
 import { json, error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { db } from "$lib/db";
-import { tripCompletions, hikes, backpacking } from "$lib/db/schemas";
-import { eq, and, desc } from "drizzle-orm";
+import { tripCompletions, hikes, campingSites, backpacking } from "$lib/db/schemas";
+import { eq, and, desc, sql } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
 import { parseLimit, parseOffset } from "$lib/utils/pagination";
 import { recomputeCompletionStats } from "$lib/server/completions";
+import { requireExactlyOneEntityRef } from "$lib/server/entity-refs";
 
 // POST /api/completions - Log a hike, camping site, or backpacking trip as completed
-export const POST: RequestHandler = async ({ request, locals }) => {
-  const user = requireAuth({ locals } as any);
+export const POST: RequestHandler = async ({ request, locals, url }) => {
+  const user = requireAuth({ locals, url } as any);
 
   const body = await request.json();
   const { hikeId, campingSiteId, backpackingId, nights } = body;
 
-  const entityCount = [hikeId, campingSiteId, backpackingId].filter(Boolean).length;
-  if (entityCount !== 1) {
-    throw error(400, "Exactly one of hikeId, campingSiteId, or backpackingId is required");
-  }
+  const exactlyOneMessage = "Exactly one of hikeId, campingSiteId, or backpackingId is required";
+  requireExactlyOneEntityRef(
+    { hikeId, campingSiteId, backpackingId },
+    { missing: exactlyOneMessage, tooMany: exactlyOneMessage }
+  );
 
   let distance: string | null = null;
   let distanceUnit: "miles" | "kilometers" | null = null;
@@ -48,6 +50,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     elevation = listing.elevation;
     elevationUnit = listing.elevationUnit;
   } else if (campingSiteId) {
+    const listing = await db.query.campingSites.findFirst({
+      where: eq(campingSites.id, campingSiteId),
+    });
+    if (!listing) throw error(404, "Camping site not found");
     if (!Number.isInteger(nights) || nights < 1 || nights > 90) {
       throw error(
         400,
@@ -83,11 +89,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 // Optional entity filters narrow to one listing; with no filter, returns the
 // caller's full history (paginated), newest first, joined to each entity's name.
 export const GET: RequestHandler = async ({ url, locals }) => {
-  const user = requireAuth({ locals } as any);
+  const user = requireAuth({ locals, url } as any);
 
   const hikeId = url.searchParams.get("hike_id");
   const campingSiteId = url.searchParams.get("camping_site_id");
   const backpackingId = url.searchParams.get("backpacking_id");
+  const countOnly = url.searchParams.get("count_only") === "true";
   const limit = parseLimit(url.searchParams.get("limit"));
   const offset = parseOffset(url.searchParams.get("offset"));
 
@@ -95,6 +102,14 @@ export const GET: RequestHandler = async ({ url, locals }) => {
   if (hikeId) conditions.push(eq(tripCompletions.hikeId, hikeId));
   if (campingSiteId) conditions.push(eq(tripCompletions.campingSiteId, campingSiteId));
   if (backpackingId) conditions.push(eq(tripCompletions.backpackingId, backpackingId));
+
+  if (countOnly) {
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::integer` })
+      .from(tripCompletions)
+      .where(and(...conditions));
+    return json({ count: row?.count ?? 0 }, { headers: { "Cache-Control": "no-store" } });
+  }
 
   const results = await db.query.tripCompletions.findMany({
     where: and(...conditions),

--- a/src/routes/api/completions/[id]/+server.ts
+++ b/src/routes/api/completions/[id]/+server.ts
@@ -10,8 +10,14 @@ import { recomputeCompletionStats } from "$lib/server/completions";
 // log entries. Targets the log row's own primary key rather than
 // entity-matched query params (KTD8), since repeat logging means more than
 // one entry can exist for the same hike/camping-site/backpacking trip.
-export const DELETE: RequestHandler = async ({ params, locals }) => {
-  const user = requireAuth({ locals } as any);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const DELETE: RequestHandler = async ({ params, locals, url }) => {
+  const user = requireAuth({ locals, url } as any);
+
+  if (!UUID_RE.test(params.id)) {
+    throw error(404, "Completion not found");
+  }
 
   const existing = await db.query.tripCompletions.findFirst({
     where: eq(tripCompletions.id, params.id),

--- a/src/routes/api/completions/[id]/+server.ts
+++ b/src/routes/api/completions/[id]/+server.ts
@@ -1,0 +1,40 @@
+import { json, error } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { db } from "$lib/db";
+import { tripCompletions } from "$lib/db/schemas";
+import { eq } from "drizzle-orm";
+import { requireAuth } from "$lib/auth/middleware";
+import { recomputeCompletionStats } from "$lib/server/completions";
+
+// DELETE /api/completions/[id] - Delete one of the caller's own completion
+// log entries. Targets the log row's own primary key rather than
+// entity-matched query params (KTD8), since repeat logging means more than
+// one entry can exist for the same hike/camping-site/backpacking trip.
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+  const user = requireAuth({ locals } as any);
+
+  const existing = await db.query.tripCompletions.findFirst({
+    where: eq(tripCompletions.id, params.id),
+  });
+
+  if (!existing) {
+    throw error(404, "Completion not found");
+  }
+
+  if (existing.userId !== user.id) {
+    throw error(403, "You can only delete your own completion entries");
+  }
+
+  await db.delete(tripCompletions).where(eq(tripCompletions.id, params.id));
+
+  const stats = await recomputeCompletionStats(user.id);
+
+  return json({
+    success: true,
+    stats: {
+      totalMiles: stats.total_miles,
+      totalNights: stats.total_nights,
+      tripCount: stats.trip_count,
+    },
+  });
+};

--- a/src/routes/api/completions/my-stats/+server.ts
+++ b/src/routes/api/completions/my-stats/+server.ts
@@ -1,0 +1,26 @@
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { db } from "$lib/db";
+import { completionStats } from "$lib/db/schemas";
+import { eq } from "drizzle-orm";
+import { requireAuth } from "$lib/auth/middleware";
+
+// GET /api/completions/my-stats - The caller's own lifetime completion totals.
+// Returns zeros for a user who hasn't logged any completions yet, rather
+// than a missing/null response.
+export const GET: RequestHandler = async ({ locals }) => {
+  const user = requireAuth({ locals } as any);
+
+  const stats = await db.query.completionStats.findFirst({
+    where: eq(completionStats.userId, user.id),
+  });
+
+  return json(
+    {
+      totalMiles: stats?.totalMiles ?? "0",
+      totalNights: stats?.totalNights ?? 0,
+      tripCount: stats?.tripCount ?? 0,
+    },
+    { headers: { "Cache-Control": "no-store" } }
+  );
+};

--- a/src/routes/api/completions/my-stats/+server.ts
+++ b/src/routes/api/completions/my-stats/+server.ts
@@ -8,8 +8,8 @@ import { requireAuth } from "$lib/auth/middleware";
 // GET /api/completions/my-stats - The caller's own lifetime completion totals.
 // Returns zeros for a user who hasn't logged any completions yet, rather
 // than a missing/null response.
-export const GET: RequestHandler = async ({ locals }) => {
-  const user = requireAuth({ locals } as any);
+export const GET: RequestHandler = async ({ locals, url }) => {
+  const user = requireAuth({ locals, url } as any);
 
   const stats = await db.query.completionStats.findFirst({
     where: eq(completionStats.userId, user.id),

--- a/src/routes/api/favorites/+server.ts
+++ b/src/routes/api/favorites/+server.ts
@@ -4,6 +4,7 @@ import { db } from "$lib/db";
 import { favorites } from "$lib/db/schemas";
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
+import { requireExactlyOneEntityRef } from "$lib/server/entity-refs";
 
 export const GET: RequestHandler = async ({ locals, url }) => {
   const user = requireAuth({ locals } as any);
@@ -39,14 +40,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
   const body = await request.json();
   const { hikeId, campingSiteId, backpackingId } = body;
 
-  if (!hikeId && !campingSiteId && !backpackingId) {
-    throw error(400, "Either hikeId, campingSiteId, or backpackingId is required");
-  }
-
-  const entityCount = [hikeId, campingSiteId, backpackingId].filter(Boolean).length;
-  if (entityCount > 1) {
-    throw error(400, "Cannot favorite more than one entity at once");
-  }
+  requireExactlyOneEntityRef(
+    { hikeId, campingSiteId, backpackingId },
+    {
+      missing: "Either hikeId, campingSiteId, or backpackingId is required",
+      tooMany: "Cannot favorite more than one entity at once",
+    }
+  );
 
   const [newFavorite] = await db
     .insert(favorites)

--- a/src/routes/api/hikes/[id]/+server.ts
+++ b/src/routes/api/hikes/[id]/+server.ts
@@ -1,13 +1,22 @@
 import { json, error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 import { db } from "$lib/db";
-import { hikes, addresses, ratingAggregates, files, councils, moderationQueue } from "$lib/db/schemas";
+import {
+  hikes,
+  addresses,
+  ratingAggregates,
+  files,
+  councils,
+  moderationQueue,
+  tripCompletions,
+} from "$lib/db/schemas";
 import { eq, sql, and } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
 import { isPrivilegedUser } from "$lib/auth/helpers";
 import { deleteFile } from "$lib/storage/blob";
 import { getAttribution } from "$lib/server/attribution";
 import { generateUniqueSlug } from "$lib/server/slug";
+import { recomputeCompletionStats } from "$lib/server/completions";
 
 export const GET: RequestHandler = async ({ params, locals }) => {
   const rows = await db
@@ -220,12 +229,20 @@ export const DELETE: RequestHandler = async (event) => {
     await db.delete(files).where(eq(files.entityId, hike.id));
   }
 
+  // Capture which users logged completions against this hike before the
+  // delete cascades away their trip_completions rows, so lifetime totals can
+  // be recomputed afterward instead of going stale.
+  const affectedUsers = await db
+    .selectDistinct({ userId: tripCompletions.userId })
+    .from(tripCompletions)
+    .where(eq(tripCompletions.hikeId, hike.id));
+
   await db.delete(hikes).where(eq(hikes.id, hike.id));
   await db
     .delete(moderationQueue)
-    .where(
-      and(eq(moderationQueue.entityType, "hike"), eq(moderationQueue.entityId, hike.id))
-    );
+    .where(and(eq(moderationQueue.entityType, "hike"), eq(moderationQueue.entityId, hike.id)));
+
+  await Promise.all(affectedUsers.map((u) => recomputeCompletionStats(u.userId)));
 
   return json({ success: true });
 };

--- a/src/routes/api/notes/+server.ts
+++ b/src/routes/api/notes/+server.ts
@@ -4,6 +4,7 @@ import { db } from "$lib/db";
 import { notes } from "$lib/db/schemas";
 import { eq, and, desc } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
+import { requireExactlyOneEntityRef } from "$lib/server/entity-refs";
 
 // GET /api/notes?hike_id=xxx or ?camping_site_id=xxx or ?backpacking_id=xxx or neither (all user notes)
 export const GET: RequestHandler = async ({ locals, url }) => {
@@ -66,14 +67,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
   const { hikeId, campingSiteId, backpackingId, content } = body;
 
   // Validation
-  if (!hikeId && !campingSiteId && !backpackingId) {
-    throw error(400, "Either hikeId, campingSiteId, or backpackingId is required");
-  }
-
-  const entityCount = [hikeId, campingSiteId, backpackingId].filter(Boolean).length;
-  if (entityCount > 1) {
-    throw error(400, "Cannot create note for more than one entity at once");
-  }
+  requireExactlyOneEntityRef(
+    { hikeId, campingSiteId, backpackingId },
+    {
+      missing: "Either hikeId, campingSiteId, or backpackingId is required",
+      tooMany: "Cannot create note for more than one entity at once",
+    }
+  );
 
   if (!content || typeof content !== "string") {
     throw error(400, "Content is required");

--- a/src/routes/api/profile/+server.ts
+++ b/src/routes/api/profile/+server.ts
@@ -23,7 +23,7 @@ export const PUT: RequestHandler = async ({ request, locals }) => {
   const user = requireAuth({ locals } as any);
 
   const body = await request.json();
-  const { councilId, unitType, unitNumber, showUnitInfo } = body;
+  const { councilId, unitType, unitNumber, showUnitInfo, shareCompletionStats } = body;
 
   // Validate unitType
   if (unitType !== undefined && !VALID_UNIT_TYPES.includes(unitType)) {
@@ -49,6 +49,8 @@ export const PUT: RequestHandler = async ({ request, locals }) => {
   if (unitType !== undefined) values.unitType = unitType || null;
   if (unitNumber !== undefined) values.unitNumber = unitNumber || null;
   if (showUnitInfo !== undefined) values.showUnitInfo = Boolean(showUnitInfo);
+  if (shareCompletionStats !== undefined)
+    values.shareCompletionStats = Boolean(shareCompletionStats);
 
   const [profile] = await db
     .insert(userProfiles)
@@ -60,6 +62,9 @@ export const PUT: RequestHandler = async ({ request, locals }) => {
         ...(unitType !== undefined && { unitType: unitType || null }),
         ...(unitNumber !== undefined && { unitNumber: unitNumber || null }),
         ...(showUnitInfo !== undefined && { showUnitInfo: Boolean(showUnitInfo) }),
+        ...(shareCompletionStats !== undefined && {
+          shareCompletionStats: Boolean(shareCompletionStats),
+        }),
         updatedAt: now,
       },
     })

--- a/src/routes/api/ratings/+server.ts
+++ b/src/routes/api/ratings/+server.ts
@@ -4,6 +4,7 @@ import { db } from "$lib/db";
 import { ratings, ratingAggregates } from "$lib/db/schemas";
 import { eq, and, sql, desc } from "drizzle-orm";
 import { requireAuth } from "$lib/auth/middleware";
+import { requireExactlyOneEntityRef } from "$lib/server/entity-refs";
 import { sanitizeReview } from "$lib/utils/profanity-filter";
 import { parseLimit, parseOffset } from "$lib/utils/pagination";
 import { getAttributions } from "$lib/server/attribution";
@@ -81,14 +82,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
   const { hikeId, campingSiteId, backpackingId, rating, reviewText } = body;
 
   // Validation
-  if (!hikeId && !campingSiteId && !backpackingId) {
-    throw error(400, "Either hikeId, campingSiteId, or backpackingId is required");
-  }
-
-  const entityCount = [hikeId, campingSiteId, backpackingId].filter(Boolean).length;
-  if (entityCount > 1) {
-    throw error(400, "Cannot rate more than one entity at once");
-  }
+  requireExactlyOneEntityRef(
+    { hikeId, campingSiteId, backpackingId },
+    {
+      missing: "Either hikeId, campingSiteId, or backpackingId is required",
+      tooMany: "Cannot rate more than one entity at once",
+    }
+  );
 
   if (!rating || typeof rating !== "number") {
     throw error(400, "Rating is required and must be a number");

--- a/src/routes/backpacking/[id]/+page.svelte
+++ b/src/routes/backpacking/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { replaceState, goto } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
+  import LogCompletionButton from "$lib/components/LogCompletionButton.svelte";
   import ShareButton from "$lib/components/ShareButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
   import Badge from "$lib/components/Badge.svelte";
@@ -246,58 +247,87 @@
 </script>
 
 <svelte:head>
-  <title>{data.backpacking.name}{locationString ? ` – ${locationString}` : ''} | Backpacking Route – Adventure Spark</title>
-  <meta name="description" content={[
-    data.backpacking.description ? data.backpacking.description.slice(0, 140).replace(/\s\S*$/, '') + '…' : null,
-    difficultyLabel ? `${difficultyLabel} difficulty.` : null,
-    data.backpacking.distance ? `${data.backpacking.distance}${data.backpacking.distanceUnit === 'kilometers' ? 'km' : 'mi'}.` : null,
-    data.backpacking.numberOfDays ? `${data.backpacking.numberOfDays} day${data.backpacking.numberOfDays !== 1 ? 's' : ''}.` : null,
-    locationString || null,
-  ].filter(Boolean).join(' ') || `Explore the ${data.backpacking.name} backpacking route on Adventure Spark.`} />
-  <meta property="og:title" content="{data.backpacking.name}{locationString ? ` – ${locationString}` : ''}" />
-  <meta property="og:description" content={data.backpacking.description ? data.backpacking.description.slice(0, 200) : `Explore the ${data.backpacking.name} backpacking route on Adventure Spark.`} />
+  <title
+    >{data.backpacking.name}{locationString ? ` – ${locationString}` : ""} | Backpacking Route – Adventure
+    Spark</title
+  >
+  <meta
+    name="description"
+    content={[
+      data.backpacking.description
+        ? data.backpacking.description.slice(0, 140).replace(/\s\S*$/, "") + "…"
+        : null,
+      difficultyLabel ? `${difficultyLabel} difficulty.` : null,
+      data.backpacking.distance
+        ? `${data.backpacking.distance}${data.backpacking.distanceUnit === "kilometers" ? "km" : "mi"}.`
+        : null,
+      data.backpacking.numberOfDays
+        ? `${data.backpacking.numberOfDays} day${data.backpacking.numberOfDays !== 1 ? "s" : ""}.`
+        : null,
+      locationString || null,
+    ]
+      .filter(Boolean)
+      .join(" ") || `Explore the ${data.backpacking.name} backpacking route on Adventure Spark.`}
+  />
+  <meta
+    property="og:title"
+    content="{data.backpacking.name}{locationString ? ` – ${locationString}` : ''}"
+  />
+  <meta
+    property="og:description"
+    content={data.backpacking.description
+      ? data.backpacking.description.slice(0, 200)
+      : `Explore the ${data.backpacking.name} backpacking route on Adventure Spark.`}
+  />
   <meta property="og:type" content="article" />
   {#if data.backpacking.bannerImageUrl}
     <meta property="og:image" content={data.backpacking.bannerImageUrl} />
     <meta name="twitter:image" content={data.backpacking.bannerImageUrl} />
   {/if}
-  <meta name="twitter:card" content={data.backpacking.bannerImageUrl ? 'summary_large_image' : 'summary'} />
+  <meta
+    name="twitter:card"
+    content={data.backpacking.bannerImageUrl ? "summary_large_image" : "summary"}
+  />
   {#if data.address?.latitude && data.address?.longitude}
     <meta name="geo.position" content="{data.address.latitude};{data.address.longitude}" />
     <meta name="ICBM" content="{data.address.latitude}, {data.address.longitude}" />
   {/if}
   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-  {@html `<${'script'} type="application/ld+json">${JSON.stringify({
+  {@html `<${"script"} type="application/ld+json">${JSON.stringify({
     "@context": "https://schema.org",
     "@type": "TouristAttraction",
-    "name": data.backpacking.name,
-    "description": data.backpacking.description || undefined,
-    "url": `https://www.adventurespark.org/backpacking/${data.backpacking.slug}`,
-    ...(data.backpacking.bannerImageUrl ? { "image": data.backpacking.bannerImageUrl } : {}),
-    ...(data.address?.latitude && data.address?.longitude ? {
-      "geo": {
-        "@type": "GeoCoordinates",
-        "latitude": data.address.latitude,
-        "longitude": data.address.longitude,
-      },
-      "address": {
-        "@type": "PostalAddress",
-        ...(data.address.city ? { "addressLocality": data.address.city } : {}),
-        ...(data.address.state ? { "addressRegion": data.address.state } : {}),
-        "addressCountry": "US",
-      },
-    } : {}),
-    ...(data.ratingAggregate && data.ratingAggregate.totalRatings > 0 ? {
-      "aggregateRating": {
-        "@type": "AggregateRating",
-        "ratingValue": parseFloat(String(data.ratingAggregate.averageRating)).toFixed(1),
-        "ratingCount": data.ratingAggregate.totalRatings,
-        "reviewCount": data.ratingAggregate.totalReviews,
-        "bestRating": "5",
-        "worstRating": "1",
-      },
-    } : {}),
-  })}</${'script'}>`}
+    name: data.backpacking.name,
+    description: data.backpacking.description || undefined,
+    url: `https://www.adventurespark.org/backpacking/${data.backpacking.slug}`,
+    ...(data.backpacking.bannerImageUrl ? { image: data.backpacking.bannerImageUrl } : {}),
+    ...(data.address?.latitude && data.address?.longitude
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: data.address.latitude,
+            longitude: data.address.longitude,
+          },
+          address: {
+            "@type": "PostalAddress",
+            ...(data.address.city ? { addressLocality: data.address.city } : {}),
+            ...(data.address.state ? { addressRegion: data.address.state } : {}),
+            addressCountry: "US",
+          },
+        }
+      : {}),
+    ...(data.ratingAggregate && data.ratingAggregate.totalRatings > 0
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: parseFloat(String(data.ratingAggregate.averageRating)).toFixed(1),
+            ratingCount: data.ratingAggregate.totalRatings,
+            reviewCount: data.ratingAggregate.totalReviews,
+            bestRating: "5",
+            worstRating: "1",
+          },
+        }
+      : {}),
+  })}</${"script"}>`}
 </svelte:head>
 
 <div class="min-h-screen bg-gray-100">
@@ -311,8 +341,12 @@
         <ChevronLeft size={24} class="text-indigo-600" />
       </a>
       <div class="flex items-center gap-2">
-        <ShareButton title={data.backpacking.name} description={data.backpacking.description ?? ""} />
+        <ShareButton
+          title={data.backpacking.name}
+          description={data.backpacking.description ?? ""}
+        />
         <FavoriteButton backpackingId={data.backpacking.id} userId={data.userId} />
+        <LogCompletionButton backpackingId={data.backpacking.id} userId={data.userId} />
         <ModerationBadge status={data.backpacking.status} userRole={typedUserRole} />
         {#if isAdmin && data.backpacking.status === "rejected"}
           <button

--- a/src/routes/camping/[id]/+page.svelte
+++ b/src/routes/camping/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { replaceState, goto } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
+  import LogCompletionButton from "$lib/components/LogCompletionButton.svelte";
   import ShareButton from "$lib/components/ShareButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
   import Badge from "$lib/components/Badge.svelte";
@@ -251,56 +252,83 @@
 </script>
 
 <svelte:head>
-  <title>{data.campingSite.name}{campingLocationString ? ` – ${campingLocationString}` : ''} | Camping Site – Adventure Spark</title>
-  <meta name="description" content={[
-    data.campingSite.description ? data.campingSite.description.slice(0, 140).replace(/\s\S*$/, '') + '…' : null,
-    data.campingSite.siteType ? `${SITE_TYPE_LABELS[data.campingSite.siteType] ?? data.campingSite.siteType} campsite.` : null,
-    campingLocationString || null,
-  ].filter(Boolean).join(' ') || `Explore ${data.campingSite.name} camping site on Adventure Spark.`} />
-  <meta property="og:title" content="{data.campingSite.name}{campingLocationString ? ` – ${campingLocationString}` : ''}" />
-  <meta property="og:description" content={data.campingSite.description ? data.campingSite.description.slice(0, 200) : `Explore ${data.campingSite.name} camping site on Adventure Spark.`} />
+  <title
+    >{data.campingSite.name}{campingLocationString ? ` – ${campingLocationString}` : ""} | Camping Site
+    – Adventure Spark</title
+  >
+  <meta
+    name="description"
+    content={[
+      data.campingSite.description
+        ? data.campingSite.description.slice(0, 140).replace(/\s\S*$/, "") + "…"
+        : null,
+      data.campingSite.siteType
+        ? `${SITE_TYPE_LABELS[data.campingSite.siteType] ?? data.campingSite.siteType} campsite.`
+        : null,
+      campingLocationString || null,
+    ]
+      .filter(Boolean)
+      .join(" ") || `Explore ${data.campingSite.name} camping site on Adventure Spark.`}
+  />
+  <meta
+    property="og:title"
+    content="{data.campingSite.name}{campingLocationString ? ` – ${campingLocationString}` : ''}"
+  />
+  <meta
+    property="og:description"
+    content={data.campingSite.description
+      ? data.campingSite.description.slice(0, 200)
+      : `Explore ${data.campingSite.name} camping site on Adventure Spark.`}
+  />
   <meta property="og:type" content="article" />
   {#if data.campingSite.bannerImageUrl}
     <meta property="og:image" content={data.campingSite.bannerImageUrl} />
     <meta name="twitter:image" content={data.campingSite.bannerImageUrl} />
   {/if}
-  <meta name="twitter:card" content={data.campingSite.bannerImageUrl ? 'summary_large_image' : 'summary'} />
+  <meta
+    name="twitter:card"
+    content={data.campingSite.bannerImageUrl ? "summary_large_image" : "summary"}
+  />
   {#if data.address?.latitude && data.address?.longitude}
     <meta name="geo.position" content="{data.address.latitude};{data.address.longitude}" />
     <meta name="ICBM" content="{data.address.latitude}, {data.address.longitude}" />
   {/if}
   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-  {@html `<${'script'} type="application/ld+json">${JSON.stringify({
+  {@html `<${"script"} type="application/ld+json">${JSON.stringify({
     "@context": "https://schema.org",
     "@type": "Campground",
-    "name": data.campingSite.name,
-    "description": data.campingSite.description || undefined,
-    "url": `https://www.adventurespark.org/camping/${data.campingSite.slug}`,
-    ...(data.campingSite.bannerImageUrl ? { "image": data.campingSite.bannerImageUrl } : {}),
-    ...(data.address?.latitude && data.address?.longitude ? {
-      "geo": {
-        "@type": "GeoCoordinates",
-        "latitude": data.address.latitude,
-        "longitude": data.address.longitude,
-      },
-      "address": {
-        "@type": "PostalAddress",
-        ...(data.address.city ? { "addressLocality": data.address.city } : {}),
-        ...(data.address.state ? { "addressRegion": data.address.state } : {}),
-        "addressCountry": "US",
-      },
-    } : {}),
-    ...(data.ratingAggregate && data.ratingAggregate.totalRatings > 0 ? {
-      "aggregateRating": {
-        "@type": "AggregateRating",
-        "ratingValue": parseFloat(String(data.ratingAggregate.averageRating)).toFixed(1),
-        "ratingCount": data.ratingAggregate.totalRatings,
-        "reviewCount": data.ratingAggregate.totalReviews,
-        "bestRating": "5",
-        "worstRating": "1",
-      },
-    } : {}),
-  })}</${'script'}>`}
+    name: data.campingSite.name,
+    description: data.campingSite.description || undefined,
+    url: `https://www.adventurespark.org/camping/${data.campingSite.slug}`,
+    ...(data.campingSite.bannerImageUrl ? { image: data.campingSite.bannerImageUrl } : {}),
+    ...(data.address?.latitude && data.address?.longitude
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: data.address.latitude,
+            longitude: data.address.longitude,
+          },
+          address: {
+            "@type": "PostalAddress",
+            ...(data.address.city ? { addressLocality: data.address.city } : {}),
+            ...(data.address.state ? { addressRegion: data.address.state } : {}),
+            addressCountry: "US",
+          },
+        }
+      : {}),
+    ...(data.ratingAggregate && data.ratingAggregate.totalRatings > 0
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: parseFloat(String(data.ratingAggregate.averageRating)).toFixed(1),
+            ratingCount: data.ratingAggregate.totalRatings,
+            reviewCount: data.ratingAggregate.totalReviews,
+            bestRating: "5",
+            worstRating: "1",
+          },
+        }
+      : {}),
+  })}</${"script"}>`}
 </svelte:head>
 
 <div class="min-h-screen bg-gray-100">
@@ -314,8 +342,12 @@
         <ChevronLeft size={24} class="text-indigo-600" />
       </a>
       <div class="flex items-center gap-2">
-        <ShareButton title={data.campingSite.name} description={data.campingSite.description ?? ""} />
+        <ShareButton
+          title={data.campingSite.name}
+          description={data.campingSite.description ?? ""}
+        />
         <FavoriteButton campingSiteId={data.campingSite.id} userId={data.userId} />
+        <LogCompletionButton campingSiteId={data.campingSite.id} userId={data.userId} />
         <ModerationBadge status={data.campingSite.status} userRole={typedUserRole} />
         {#if isAdmin && data.campingSite.status === "rejected"}
           <button

--- a/src/routes/hikes/[id]/+page.svelte
+++ b/src/routes/hikes/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { replaceState, invalidateAll, goto } from "$app/navigation";
   import type { PageData } from "./$types";
   import FavoriteButton from "$lib/components/FavoriteButton.svelte";
+  import LogCompletionButton from "$lib/components/LogCompletionButton.svelte";
   import ShareButton from "$lib/components/ShareButton.svelte";
   import ModerationBadge from "$lib/components/ModerationBadge.svelte";
   import Badge from "$lib/components/Badge.svelte";
@@ -243,57 +244,83 @@
 </script>
 
 <svelte:head>
-  <title>{data.hike.name}{locationString ? ` – ${locationString}` : ''} | Hiking Trail – Adventure Spark</title>
-  <meta name="description" content={[
-    data.hike.description ? data.hike.description.slice(0, 140).replace(/\s\S*$/, '') + '…' : null,
-    difficultyLabel ? `${difficultyLabel} difficulty.` : null,
-    data.hike.distance ? `${data.hike.distance}${data.hike.distanceUnit === 'kilometers' ? 'km' : 'mi'}.` : null,
-    locationString || null,
-  ].filter(Boolean).join(' ') || `Explore the ${data.hike.name} hiking trail on Adventure Spark.`} />
-  <meta property="og:title" content="{data.hike.name}{locationString ? ` – ${locationString}` : ''}" />
-  <meta property="og:description" content={data.hike.description ? data.hike.description.slice(0, 200) : `Explore the ${data.hike.name} hiking trail on Adventure Spark.`} />
+  <title
+    >{data.hike.name}{locationString ? ` – ${locationString}` : ""} | Hiking Trail – Adventure Spark</title
+  >
+  <meta
+    name="description"
+    content={[
+      data.hike.description
+        ? data.hike.description.slice(0, 140).replace(/\s\S*$/, "") + "…"
+        : null,
+      difficultyLabel ? `${difficultyLabel} difficulty.` : null,
+      data.hike.distance
+        ? `${data.hike.distance}${data.hike.distanceUnit === "kilometers" ? "km" : "mi"}.`
+        : null,
+      locationString || null,
+    ]
+      .filter(Boolean)
+      .join(" ") || `Explore the ${data.hike.name} hiking trail on Adventure Spark.`}
+  />
+  <meta
+    property="og:title"
+    content="{data.hike.name}{locationString ? ` – ${locationString}` : ''}"
+  />
+  <meta
+    property="og:description"
+    content={data.hike.description
+      ? data.hike.description.slice(0, 200)
+      : `Explore the ${data.hike.name} hiking trail on Adventure Spark.`}
+  />
   <meta property="og:type" content="article" />
   {#if data.hike.bannerImageUrl}
     <meta property="og:image" content={data.hike.bannerImageUrl} />
     <meta name="twitter:image" content={data.hike.bannerImageUrl} />
   {/if}
-  <meta name="twitter:card" content={data.hike.bannerImageUrl ? 'summary_large_image' : 'summary'} />
+  <meta
+    name="twitter:card"
+    content={data.hike.bannerImageUrl ? "summary_large_image" : "summary"}
+  />
   {#if data.address?.latitude && data.address?.longitude}
     <meta name="geo.position" content="{data.address.latitude};{data.address.longitude}" />
     <meta name="ICBM" content="{data.address.latitude}, {data.address.longitude}" />
   {/if}
   <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-  {@html `<${'script'} type="application/ld+json">${JSON.stringify({
+  {@html `<${"script"} type="application/ld+json">${JSON.stringify({
     "@context": "https://schema.org",
     "@type": "TouristAttraction",
-    "name": data.hike.name,
-    "description": data.hike.description || undefined,
-    "url": `https://www.adventurespark.org/hikes/${data.hike.slug}`,
-    ...(data.hike.bannerImageUrl ? { "image": data.hike.bannerImageUrl } : {}),
-    ...(data.address?.latitude && data.address?.longitude ? {
-      "geo": {
-        "@type": "GeoCoordinates",
-        "latitude": data.address.latitude,
-        "longitude": data.address.longitude,
-      },
-      "address": {
-        "@type": "PostalAddress",
-        ...(data.address.city ? { "addressLocality": data.address.city } : {}),
-        ...(data.address.state ? { "addressRegion": data.address.state } : {}),
-        "addressCountry": "US",
-      },
-    } : {}),
-    ...(data.ratingAggregate && data.ratingAggregate.totalRatings > 0 ? {
-      "aggregateRating": {
-        "@type": "AggregateRating",
-        "ratingValue": parseFloat(String(data.ratingAggregate.averageRating)).toFixed(1),
-        "ratingCount": data.ratingAggregate.totalRatings,
-        "reviewCount": data.ratingAggregate.totalReviews,
-        "bestRating": "5",
-        "worstRating": "1",
-      },
-    } : {}),
-  })}</${'script'}>`}
+    name: data.hike.name,
+    description: data.hike.description || undefined,
+    url: `https://www.adventurespark.org/hikes/${data.hike.slug}`,
+    ...(data.hike.bannerImageUrl ? { image: data.hike.bannerImageUrl } : {}),
+    ...(data.address?.latitude && data.address?.longitude
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: data.address.latitude,
+            longitude: data.address.longitude,
+          },
+          address: {
+            "@type": "PostalAddress",
+            ...(data.address.city ? { addressLocality: data.address.city } : {}),
+            ...(data.address.state ? { addressRegion: data.address.state } : {}),
+            addressCountry: "US",
+          },
+        }
+      : {}),
+    ...(data.ratingAggregate && data.ratingAggregate.totalRatings > 0
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: parseFloat(String(data.ratingAggregate.averageRating)).toFixed(1),
+            ratingCount: data.ratingAggregate.totalRatings,
+            reviewCount: data.ratingAggregate.totalReviews,
+            bestRating: "5",
+            worstRating: "1",
+          },
+        }
+      : {}),
+  })}</${"script"}>`}
 </svelte:head>
 
 <div class="min-h-screen bg-gray-100">
@@ -309,6 +336,7 @@
       <div class="flex items-center gap-2">
         <ShareButton title={data.hike.name} description={data.hike.description ?? ""} />
         <FavoriteButton hikeId={data.hike.id} userId={data.userId} />
+        <LogCompletionButton hikeId={data.hike.id} userId={data.userId} />
         <ModerationBadge status={data.hike.status} userRole={typedUserRole} />
         {#if isAdmin && data.hike.status === "rejected"}
           <button

--- a/src/routes/profile/+page.server.ts
+++ b/src/routes/profile/+page.server.ts
@@ -86,33 +86,4 @@ export const actions: Actions = {
 
     return { profileSuccess: true };
   },
-
-  // Separate from saveProfile so toggling sharing from the Adventures tab
-  // never touches council/unit fields it doesn't have inputs for.
-  saveSharingPreference: async ({ request, locals }) => {
-    if (!locals.user) {
-      return fail(401, { sharingError: "Not authenticated" });
-    }
-
-    const formData = await request.formData();
-    const shareCompletionStats = formData.get("shareCompletionStats") === "on";
-
-    await db
-      .insert(userProfiles)
-      .values({
-        userId: locals.user.id,
-        shareCompletionStats,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: userProfiles.userId,
-        set: {
-          shareCompletionStats,
-          updatedAt: new Date(),
-        },
-      });
-
-    return { sharingSuccess: true };
-  },
 };

--- a/src/routes/profile/+page.server.ts
+++ b/src/routes/profile/+page.server.ts
@@ -86,4 +86,33 @@ export const actions: Actions = {
 
     return { profileSuccess: true };
   },
+
+  // Separate from saveProfile so toggling sharing from the Adventures tab
+  // never touches council/unit fields it doesn't have inputs for.
+  saveSharingPreference: async ({ request, locals }) => {
+    if (!locals.user) {
+      return fail(401, { sharingError: "Not authenticated" });
+    }
+
+    const formData = await request.formData();
+    const shareCompletionStats = formData.get("shareCompletionStats") === "on";
+
+    await db
+      .insert(userProfiles)
+      .values({
+        userId: locals.user.id,
+        shareCompletionStats,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: userProfiles.userId,
+        set: {
+          shareCompletionStats,
+          updatedAt: new Date(),
+        },
+      });
+
+    return { sharingSuccess: true };
+  },
 };

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -4,6 +4,7 @@
   import { enhance } from "$app/forms";
   import Tabs from "$lib/components/Tabs.svelte";
   import NotesSection from "$lib/components/NotesSection.svelte";
+  import MyAdventures from "$lib/components/MyAdventures.svelte";
   import { Check, CircleAlertIcon, LogOut, Mail, UserCircle, Shield } from "lucide-svelte";
   import CouncilSelect from "$lib/components/CouncilSelect.svelte";
 
@@ -15,6 +16,7 @@
     { id: "profile", label: "Profile" },
     { id: "security", label: "Security" },
     { id: "notes", label: "My Notes" },
+    { id: "adventures", label: "My Adventures" },
   ];
 
   let isRequestingReset = false;
@@ -316,6 +318,12 @@
           {:else if activeTab === "notes"}
             <div class="pb-6">
               <NotesSection userId={data.user.id} />
+            </div>
+          {:else if activeTab === "adventures"}
+            <div class="pb-6">
+              <MyAdventures
+                initialShareCompletionStats={data.profile?.shareCompletionStats ?? false}
+              />
             </div>
           {/if}
         </Tabs>


### PR DESCRIPTION
Lets scouts self-report completed hikes, camping stays, and backpacking trips from the listing detail page, with per-user lifetime totals (miles hiked, nights camped, trip count) shown on a new profile tab. Private by default with an opt-in sharing toggle. Users can delete their own log entries.

Implements docs/plans/2026-07-09-001-feat-trip-completion-log-plan.md.