### PR TITLE
feat: redesign trip completion logging as an icon + modal

### DIFF
--- a/e2e/completions.user.spec.ts
+++ b/e2e/completions.user.spec.ts
@@ -1,8 +1,15 @@
 import { test, expect } from "./fixtures/base-test";
 import { getHikeId, getCampingId } from "./fixtures/helpers";
 
+function countFromLabel(label: string | null): number {
+  const match = label?.match(/logged (\d+) time/);
+  return match ? Number(match[1]) : 0;
+}
+
 test.describe("Trip completion log – authenticated user", () => {
-  test("logs a hike as completed and increments the visible count", async ({ page }) => {
+  test("logs a hike as completed via the modal and increments the visible count", async ({
+    page,
+  }) => {
     const hikeId = getHikeId();
     await page.goto(`/hikes/${hikeId}`);
     await page.waitForLoadState("load");
@@ -10,9 +17,10 @@ test.describe("Trip completion log – authenticated user", () => {
     const logBtn = page.getByRole("button", { name: /Log as completed/ });
     await expect(logBtn).toBeVisible();
 
-    const initialText = (await logBtn.textContent()) ?? "";
-    const initialMatch = initialText.match(/logged (\d+) time/);
-    const initialCount = initialMatch ? Number(initialMatch[1]) : 0;
+    const initialCount = countFromLabel(await logBtn.getAttribute("aria-label"));
+
+    await logBtn.click();
+    await expect(page.getByRole("button", { name: "Log completion" })).toBeVisible();
 
     await Promise.all([
       page.waitForResponse(
@@ -21,10 +29,13 @@ test.describe("Trip completion log – authenticated user", () => {
           r.request().method() === "POST" &&
           r.status() < 300
       ),
-      logBtn.click(),
+      page.getByRole("button", { name: "Log completion" }).click(),
     ]);
 
-    await expect(page.getByText(`logged ${initialCount + 1} time`)).toBeVisible();
+    await expect(logBtn).toHaveAttribute(
+      "aria-label",
+      new RegExp(`logged ${initialCount + 1} time`)
+    );
   });
 
   test("clicking the log button repeatedly creates independent entries, not a toggle", async ({
@@ -35,11 +46,11 @@ test.describe("Trip completion log – authenticated user", () => {
     await page.waitForLoadState("load");
 
     const logBtn = page.getByRole("button", { name: /Log as completed/ });
-    const initialText = (await logBtn.textContent()) ?? "";
-    const initialMatch = initialText.match(/logged (\d+) time/);
-    const initialCount = initialMatch ? Number(initialMatch[1]) : 0;
+    const initialCount = countFromLabel(await logBtn.getAttribute("aria-label"));
 
     for (let i = 1; i <= 2; i++) {
+      await logBtn.click();
+      await expect(page.getByRole("button", { name: "Log completion" })).toBeVisible();
       await Promise.all([
         page.waitForResponse(
           (r) =>
@@ -47,9 +58,12 @@ test.describe("Trip completion log – authenticated user", () => {
             r.request().method() === "POST" &&
             r.status() < 300
         ),
-        logBtn.click(),
+        page.getByRole("button", { name: "Log completion" }).click(),
       ]);
-      await expect(page.getByText(`logged ${initialCount + i} time`)).toBeVisible();
+      await expect(logBtn).toHaveAttribute(
+        "aria-label",
+        new RegExp(`logged ${initialCount + i} time`)
+      );
     }
   });
 
@@ -71,7 +85,7 @@ test.describe("Trip completion log – authenticated user", () => {
     await page.getByRole("button", { name: "Log completion" }).click();
     await expect(page.getByText("Enter a whole number of nights between 1 and 90")).toBeVisible();
 
-    // Valid input succeeds and collapses the form
+    // Valid input succeeds and closes the modal
     await nightsInput.fill("3");
     await Promise.all([
       page.waitForResponse(
@@ -94,6 +108,7 @@ test.describe("Trip completion log – authenticated user", () => {
     await page.goto(`/hikes/${hikeId}`);
     await page.waitForLoadState("load");
     const logBtn = page.getByRole("button", { name: /Log as completed/ });
+    await logBtn.click();
     await Promise.all([
       page.waitForResponse(
         (r) =>
@@ -101,7 +116,7 @@ test.describe("Trip completion log – authenticated user", () => {
           r.request().method() === "POST" &&
           r.status() < 300
       ),
-      logBtn.click(),
+      page.getByRole("button", { name: "Log completion" }).click(),
     ]);
 
     // Switch to the My Adventures tab on the profile page

--- a/src/lib/components/LogCompletionButton.svelte
+++ b/src/lib/components/LogCompletionButton.svelte
@@ -1,25 +1,51 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { CheckCircle2 } from "lucide-svelte";
+  import { onMount, onDestroy } from "svelte";
+  import { browser } from "$app/environment";
+  import { Footprints } from "lucide-svelte";
 
   export let hikeId: string | null = null;
   export let campingSiteId: string | null = null;
   export let backpackingId: string | null = null;
   export let userId: string | null = null;
+  export let defaultDistance: string | null = null;
+  export let defaultDistanceUnit: "miles" | "kilometers" | null = null;
 
   const isCamping = !!campingSiteId;
+  const distanceLabel = defaultDistanceUnit === "kilometers" ? "Kilometers hiked" : "Miles hiked";
 
   let count = 0;
+  let showTooltip = false;
+  let showModal = false;
   let submitting = false;
   let errorMessage: string | null = null;
-  let showCampingForm = false;
+  let dateInput = "";
   let nightsInput = "";
   let nightsError: string | null = null;
+  let milesInput = "";
+  let milesError: string | null = null;
+
+  $: tooltipText = !userId
+    ? "Log in to track completed trips"
+    : count > 0
+      ? `Log as completed (logged ${count} ${count === 1 ? "time" : "times"})`
+      : "Log as completed";
 
   onMount(async () => {
     if (!userId) return;
     await fetchCount();
   });
+
+  onDestroy(() => {
+    if (!browser) return;
+    document.removeEventListener("keydown", handleKeydown);
+    document.body.style.overflow = "";
+  });
+
+  function todayLocal() {
+    const d = new Date();
+    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return local.toISOString().slice(0, 10);
+  }
 
   async function fetchCount() {
     try {
@@ -37,27 +63,69 @@
     }
   }
 
-  function handleClick() {
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") requestClose();
+  }
+
+  function openModal() {
     if (!userId) {
       window.location.href = "/login";
       return;
     }
-    if (submitting) return;
+    errorMessage = null;
+    nightsError = null;
+    milesError = null;
+    dateInput = todayLocal();
+    nightsInput = "";
+    milesInput = defaultDistance ?? "";
+    showModal = true;
+    document.addEventListener("keydown", handleKeydown);
+    document.body.style.overflow = "hidden";
+  }
 
+  function closeModal() {
+    showModal = false;
+    document.removeEventListener("keydown", handleKeydown);
+    document.body.style.overflow = "";
+  }
+
+  function requestClose() {
+    if (submitting) return;
+    closeModal();
+  }
+
+  async function submitLog() {
+    if (submitting) return;
+    errorMessage = null;
+    nightsError = null;
+    milesError = null;
+
+    let nights: number | undefined;
     if (isCamping) {
-      showCampingForm = !showCampingForm;
-      nightsError = null;
-      errorMessage = null;
+      const parsed = Number(nightsInput);
+      if (!Number.isInteger(parsed) || parsed < 1 || parsed > 90) {
+        nightsError = "Enter a whole number of nights between 1 and 90";
+        return;
+      }
+      nights = parsed;
+    }
+
+    let distance: number | undefined;
+    if (!isCamping && milesInput !== "") {
+      const parsed = Number(milesInput);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        milesError = "Enter a distance greater than 0";
+        return;
+      }
+      distance = parsed;
+    }
+
+    if (!dateInput || dateInput > todayLocal()) {
+      errorMessage = "Enter a valid date that isn't in the future";
       return;
     }
 
-    void logCompletion();
-  }
-
-  async function logCompletion(nights?: number) {
     submitting = true;
-    errorMessage = null;
-
     const previousCount = count;
     count = count + 1; // optimistic
 
@@ -65,15 +133,18 @@
       const response = await fetch("/api/completions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ hikeId, campingSiteId, backpackingId, nights }),
+        body: JSON.stringify({
+          hikeId,
+          campingSiteId,
+          backpackingId,
+          nights,
+          distance,
+          completedAt: dateInput,
+        }),
       });
       if (!response.ok) throw new Error("Failed to log completion");
 
-      if (isCamping) {
-        showCampingForm = false;
-        nightsInput = "";
-      }
-
+      closeModal();
       // Reconcile with the authoritative count rather than trusting the
       // optimistic increment indefinitely (it would otherwise drift after
       // deletions elsewhere, e.g. the My Adventures history).
@@ -86,84 +157,137 @@
       submitting = false;
     }
   }
-
-  function submitCampingForm() {
-    const parsed = Number(nightsInput);
-    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 90) {
-      nightsError = "Enter a whole number of nights between 1 and 90";
-      return;
-    }
-    nightsError = null;
-    void logCompletion(parsed);
-  }
 </script>
 
-<div class="inline-flex flex-col items-start gap-1">
+<div class="relative inline-flex items-center justify-center">
   <button
     type="button"
-    on:click={handleClick}
-    disabled={submitting}
+    on:click={openModal}
+    on:mouseenter={() => (showTooltip = true)}
+    on:mouseleave={() => (showTooltip = false)}
+    on:focus={() => (showTooltip = true)}
+    on:blur={() => (showTooltip = false)}
     aria-disabled={!userId || undefined}
-    aria-describedby={!userId ? "log-completion-login-hint" : undefined}
-    class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-emerald-300 text-emerald-700 bg-white hover:bg-emerald-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors {!userId
+    aria-label={tooltipText}
+    class="relative inline-flex items-center justify-center w-9 h-9 rounded-full text-emerald-700 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-400 transition-colors {!userId
       ? 'opacity-50 cursor-not-allowed'
       : ''}"
   >
-    <CheckCircle2 size={15} />
-    {submitting ? "Logging…" : "Log as completed"}
+    <Footprints size={20} />
     {#if count > 0}
-      <span class="text-xs text-emerald-600">(logged {count} {count === 1 ? "time" : "times"})</span
+      <span
+        class="absolute -top-0.5 -right-0.5 flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-emerald-600 text-white text-[10px] font-bold leading-none"
       >
+        {count}
+      </span>
     {/if}
   </button>
 
-  {#if !userId}
-    <span id="log-completion-login-hint" class="sr-only">Log in to track completed trips</span>
-  {/if}
-
-  {#if errorMessage}
-    <p class="text-xs text-red-600" role="alert">{errorMessage}</p>
-  {/if}
-
-  {#if isCamping && showCampingForm}
-    <div class="mt-1 p-3 border border-gray-200 rounded-lg bg-gray-50 space-y-2">
-      <label for="nights-stayed" class="block text-xs font-medium text-gray-700">
-        Nights stayed
-      </label>
-      <input
-        id="nights-stayed"
-        type="number"
-        min="1"
-        max="90"
-        step="1"
-        bind:value={nightsInput}
-        aria-describedby={nightsError ? "nights-stayed-error" : undefined}
-        class="w-24 px-2 py-1 text-sm border border-gray-300 rounded"
-      />
-      {#if nightsError}
-        <p id="nights-stayed-error" class="text-xs text-red-600" role="alert">{nightsError}</p>
-      {/if}
-      <div class="flex gap-2">
-        <button
-          type="button"
-          on:click={submitCampingForm}
-          disabled={submitting}
-          class="px-2.5 py-1 text-xs font-medium rounded bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-50"
-        >
-          {submitting ? "Logging…" : "Log completion"}
-        </button>
-        <button
-          type="button"
-          on:click={() => {
-            showCampingForm = false;
-            nightsError = null;
-          }}
-          disabled={submitting}
-          class="px-2.5 py-1 text-xs font-medium rounded border border-gray-300 text-gray-600 hover:bg-gray-100 disabled:opacity-50"
-        >
-          Cancel
-        </button>
-      </div>
+  {#if showTooltip}
+    <div
+      role="tooltip"
+      class="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 px-2 py-1 rounded bg-gray-900 text-white text-xs whitespace-nowrap z-20 pointer-events-none"
+    >
+      {tooltipText}
     </div>
   {/if}
 </div>
+
+{#if showModal}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+    on:click|self={requestClose}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="log-completion-title"
+    tabindex="-1"
+  >
+    <div class="bg-white rounded-lg max-w-sm w-full p-6">
+      <h3 id="log-completion-title" class="text-lg font-semibold text-gray-900 mb-4">
+        Log completed trip
+      </h3>
+
+      <div class="space-y-4">
+        <div>
+          <label for="completed-date" class="block text-sm font-medium text-gray-700 mb-1">
+            {isCamping ? "First night" : "Date completed"}
+          </label>
+          <input
+            id="completed-date"
+            type="date"
+            bind:value={dateInput}
+            max={todayLocal()}
+            class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg"
+          />
+        </div>
+
+        {#if isCamping}
+          <div>
+            <label for="nights-stayed" class="block text-sm font-medium text-gray-700 mb-1">
+              Nights stayed
+            </label>
+            <input
+              id="nights-stayed"
+              type="number"
+              min="1"
+              max="90"
+              step="1"
+              bind:value={nightsInput}
+              aria-describedby={nightsError ? "nights-stayed-error" : undefined}
+              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg"
+            />
+            {#if nightsError}
+              <p id="nights-stayed-error" class="text-xs text-red-600 mt-1" role="alert">
+                {nightsError}
+              </p>
+            {/if}
+          </div>
+        {:else}
+          <div>
+            <label for="miles-hiked" class="block text-sm font-medium text-gray-700 mb-1">
+              {distanceLabel}
+            </label>
+            <input
+              id="miles-hiked"
+              type="number"
+              min="0"
+              step="0.1"
+              bind:value={milesInput}
+              aria-describedby={milesError ? "miles-hiked-error" : undefined}
+              class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg"
+            />
+            {#if milesError}
+              <p id="miles-hiked-error" class="text-xs text-red-600 mt-1" role="alert">
+                {milesError}
+              </p>
+            {/if}
+          </div>
+        {/if}
+
+        {#if errorMessage}
+          <p class="text-sm text-red-600" role="alert">{errorMessage}</p>
+        {/if}
+      </div>
+
+      <div class="flex gap-3 justify-end mt-6">
+        <button
+          type="button"
+          on:click={requestClose}
+          disabled={submitting}
+          class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          on:click={submitLog}
+          disabled={submitting}
+          class="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {submitting ? "Logging…" : "Log completion"}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/MyAdventures.svelte
+++ b/src/lib/components/MyAdventures.svelte
@@ -14,6 +14,7 @@
     entitySlug: string | null;
     distance: string | null;
     nights: number | null;
+    completedAt: string;
     createdAt: string;
   };
 
@@ -127,7 +128,7 @@
                 {entry.entityName ?? "Unknown trip"}
               </p>
               <p class="text-xs text-stone-400">
-                {new Date(entry.createdAt).toLocaleDateString()}
+                {new Date(`${entry.completedAt}T00:00:00`).toLocaleDateString()}
                 {#if entry.distance}
                   · {Math.round(Number(entry.distance) * 10) / 10} mi
                 {/if}

--- a/src/lib/db/schemas/completions.ts
+++ b/src/lib/db/schemas/completions.ts
@@ -3,6 +3,7 @@ import {
   uuid,
   text,
   timestamp,
+  date,
   numeric,
   integer,
   check,
@@ -33,6 +34,12 @@ export const tripCompletions = pgTable(
     elevation: numeric("elevation"),
     elevationUnit: elevationUnitEnum("elevation_unit"),
     nights: integer("nights"),
+    // The day the trip actually happened, as reported by the user — distinct
+    // from createdAt (when the log entry was recorded), since users can log
+    // a past trip after the fact.
+    completedAt: date("completed_at")
+      .notNull()
+      .default(sql`CURRENT_DATE`),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => ({

--- a/src/routes/api/completions/+server.ts
+++ b/src/routes/api/completions/+server.ts
@@ -8,6 +8,40 @@ import { parseLimit, parseOffset } from "$lib/utils/pagination";
 import { recomputeCompletionStats } from "$lib/server/completions";
 import { requireExactlyOneEntityRef } from "$lib/server/entity-refs";
 
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Parses the optional "day the trip actually happened" from the request body,
+// defaulting to today and rejecting future dates (users can't log a trip
+// before they've taken it). Local-date comparison is fine here since the
+// column is a plain SQL date with no time component.
+function parseCompletedAt(value: unknown): string {
+  const today = new Date().toISOString().slice(0, 10);
+  if (value === undefined || value === null || value === "") {
+    return today;
+  }
+  if (typeof value !== "string" || !ISO_DATE_RE.test(value)) {
+    throw error(400, "completedAt must be a date in YYYY-MM-DD format");
+  }
+  if (value > today) {
+    throw error(400, "completedAt cannot be in the future");
+  }
+  return value;
+}
+
+// Users may override the snapshot distance copied from the listing (e.g. they
+// hiked a spur trail or turned back early). Returns null when not provided,
+// so the caller falls back to the listing's own distance.
+function parseDistanceOverride(value: unknown): string | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw error(400, "distance must be a positive number");
+  }
+  return parsed.toString();
+}
+
 // POST /api/completions - Log a hike, camping site, or backpacking trip as completed
 export const POST: RequestHandler = async ({ request, locals, url }) => {
   const user = requireAuth({ locals, url } as any);
@@ -21,6 +55,9 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
     { missing: exactlyOneMessage, tooMany: exactlyOneMessage }
   );
 
+  const completedAt = parseCompletedAt(body.completedAt);
+  const distanceOverride = parseDistanceOverride(body.distance);
+
   let distance: string | null = null;
   let distanceUnit: "miles" | "kilometers" | null = null;
   let duration: string | null = null;
@@ -32,7 +69,7 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
   if (hikeId) {
     const listing = await db.query.hikes.findFirst({ where: eq(hikes.id, hikeId) });
     if (!listing) throw error(404, "Hike not found");
-    distance = listing.distance;
+    distance = distanceOverride ?? listing.distance;
     distanceUnit = listing.distanceUnit;
     duration = listing.duration;
     durationUnit = listing.durationUnit;
@@ -43,7 +80,7 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
       where: eq(backpacking.id, backpackingId),
     });
     if (!listing) throw error(404, "Backpacking trip not found");
-    distance = listing.distance;
+    distance = distanceOverride ?? listing.distance;
     distanceUnit = listing.distanceUnit;
     duration = listing.duration;
     durationUnit = listing.durationUnit;
@@ -77,6 +114,7 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
       elevation,
       elevationUnit,
       nights: validatedNights,
+      completedAt,
     })
     .returning();
 
@@ -113,7 +151,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 
   const results = await db.query.tripCompletions.findMany({
     where: and(...conditions),
-    orderBy: [desc(tripCompletions.createdAt)],
+    orderBy: [desc(tripCompletions.completedAt), desc(tripCompletions.createdAt)],
     limit,
     offset,
     with: {

--- a/src/routes/backpacking/[id]/+page.svelte
+++ b/src/routes/backpacking/[id]/+page.svelte
@@ -346,7 +346,12 @@
           description={data.backpacking.description ?? ""}
         />
         <FavoriteButton backpackingId={data.backpacking.id} userId={data.userId} />
-        <LogCompletionButton backpackingId={data.backpacking.id} userId={data.userId} />
+        <LogCompletionButton
+          backpackingId={data.backpacking.id}
+          userId={data.userId}
+          defaultDistance={data.backpacking.distance}
+          defaultDistanceUnit={data.backpacking.distanceUnit}
+        />
         <ModerationBadge status={data.backpacking.status} userRole={typedUserRole} />
         {#if isAdmin && data.backpacking.status === "rejected"}
           <button

--- a/src/routes/hikes/[id]/+page.svelte
+++ b/src/routes/hikes/[id]/+page.svelte
@@ -336,7 +336,12 @@
       <div class="flex items-center gap-2">
         <ShareButton title={data.hike.name} description={data.hike.description ?? ""} />
         <FavoriteButton hikeId={data.hike.id} userId={data.userId} />
-        <LogCompletionButton hikeId={data.hike.id} userId={data.userId} />
+        <LogCompletionButton
+          hikeId={data.hike.id}
+          userId={data.userId}
+          defaultDistance={data.hike.distance}
+          defaultDistanceUnit={data.hike.distanceUnit}
+        />
         <ModerationBadge status={data.hike.status} userRole={typedUserRole} />
         {#if isAdmin && data.hike.status === "rejected"}
           <button


### PR DESCRIPTION
## Summary
- Replaces the "Log as completed" text button with an icon-only Footprints button and an instant custom tooltip (no native-tooltip delay)
- Clicking now opens a modal (hikes, camping sites, and backpacking trips) that captures the day the trip happened, plus miles hiked (defaulted from the listing, editable) or nights stayed
- Adds a `completed_at` date column to `trip_completions`, distinct from `created_at`, so a trip can be logged after the fact
- `POST /api/completions` accepts optional `completedAt` (future dates rejected) and a `distance` override; history now orders by `completedAt`
- My Adventures history now shows `completedAt` instead of `createdAt`
- Fixes an SSR crash introduced during this redesign (`onDestroy` touched `document` unconditionally, which runs synchronously during SSR)

Follow-up to #90 (already merged).

## Test plan
- [x] `npx tsc --noEmit`, `npm run check`, `npm run lint`, `npm run test:unit` all pass (same 2 pre-existing unrelated errors, 27/27 unit tests)
- [x] Verified the full POST/GET/DELETE flow (default distance, distance override, future-date rejection, invalid-distance rejection, camping nights + date, `count_only`) directly against the dev server via authenticated fetch calls, then cleaned up test data
- [x] Verified on the Profile page (My Adventures tab) that `completedAt` renders correctly and the sharing toggle still works
- [ ] Could not click through the modal live in Chrome — hike/camping/backpacking detail pages hit a pre-existing hydration bug unrelated to this change (`Cannot call replaceState before router is initialized`, fires on any interaction including hover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)